### PR TITLE
Correction affichage menus des joueurs d'un autre secteur - v2

### DIFF
--- a/dtn/interface/consulter/rechercheJoueur.php
+++ b/dtn/interface/consulter/rechercheJoueur.php
@@ -127,7 +127,8 @@ jours</TD>
 						<TD COLSPAN="1" VALIGN="middle"><B>Sp&eacute;cialit&eacute; :&nbsp; </B></TD>
 						<TD COLSPAN="2" VALIGN="top">
 							<Select NAME="specialty">
-							<Option VALUE="-1" SELECTED>-- Toutes --</OPTION>
+							<Option VALUE="-1" SELECTED>-- Pas de pr√©f√©rence --</OPTION>
+							<Option VALUE="99" >Toutes</OPTION>
 							<Option VALUE="0" >Aucune</OPTION>
 							<Option VALUE="1" >Technique</OPTION>
 							<Option VALUE="2" >Rapide</OPTION>
@@ -612,7 +613,7 @@ jours</TD>
 						<INPUT TYPE="radio" NAME="NivEntraineur" VALUE="-1" CHECKED>Tous
 						<INPUT TYPE="radio" NAME="NivEntraineur" VALUE="8" >Excellent
 						<INPUT TYPE="radio" NAME="NivEntraineur" VALUE="7" >Honorable
-						<INPUT TYPE="radio" NAME="NivEntraineur" VALUE="6" >Passable ou infÈrieur
+						<INPUT TYPE="radio" NAME="NivEntraineur" VALUE="6" >Passable ou inf√©rieur
 						<BR>
 						<BR><B>Tri des r&eacute;sultats :</B><BR>
 						<SELECT NAME="ordreDeTriNb" SIZE=1>
@@ -622,11 +623,11 @@ jours</TD>
 							<OPTION VALUE="18">Tri par mise &agrave; jour propri&eacute;taire</OPTION>
 							<OPTION VALUE="19">Tri par mise &agrave; jour propri&eacute;taire invers&eacute;e</OPTION>
 							<OPTION VALUE="3">Tri par TSI </OPTION>
-							<OPTION VALUE="20">Tri par salaire rÈel</OPTION>
+							<OPTION VALUE="20">Tri par salaire r√©el</OPTION>
 							<OPTION VALUE="21">Tri par salaire de base</OPTION>
               <OPTION VALUE="23">Tri par salaire de base invers&eacute;</OPTION>
-              <OPTION VALUE="24">Tri par ‚ge</OPTION>
-              <OPTION VALUE="25">Tri par ‚ge invers&eacute;</OPTION>
+              <OPTION VALUE="24">Tri par √¢ge</OPTION>
+              <OPTION VALUE="25">Tri par √¢ge invers&eacute;</OPTION>
               <OPTION VALUE="26">Tri par TDC</OPTION>
               <OPTION VALUE="4">Tri par id Hattrick </OPTION>
 							<OPTION VALUE="5">Tri par note gK </OPTION>

--- a/dtn/interface/consulter/rechercheJoueur.php
+++ b/dtn/interface/consulter/rechercheJoueur.php
@@ -127,7 +127,7 @@ jours</TD>
 						<TD COLSPAN="1" VALIGN="middle"><B>Sp&eacute;cialit&eacute; :&nbsp; </B></TD>
 						<TD COLSPAN="2" VALIGN="top">
 							<Select NAME="specialty">
-							<Option VALUE="-1" SELECTED>-- Pas de préférence --</OPTION>
+							<Option VALUE="-1" SELECTED>-- Pas de pr&eacute;f&eacute;rence --</OPTION>
 							<Option VALUE="99" >Toutes</OPTION>
 							<Option VALUE="0" >Aucune</OPTION>
 							<Option VALUE="1" >Technique</OPTION>
@@ -613,7 +613,7 @@ jours</TD>
 						<INPUT TYPE="radio" NAME="NivEntraineur" VALUE="-1" CHECKED>Tous
 						<INPUT TYPE="radio" NAME="NivEntraineur" VALUE="8" >Excellent
 						<INPUT TYPE="radio" NAME="NivEntraineur" VALUE="7" >Honorable
-						<INPUT TYPE="radio" NAME="NivEntraineur" VALUE="6" >Passable ou inférieur
+						<INPUT TYPE="radio" NAME="NivEntraineur" VALUE="6" >Passable ou inf&eacute;rieur
 						<BR>
 						<BR><B>Tri des r&eacute;sultats :</B><BR>
 						<SELECT NAME="ordreDeTriNb" SIZE=1>
@@ -623,7 +623,7 @@ jours</TD>
 							<OPTION VALUE="18">Tri par mise &agrave; jour propri&eacute;taire</OPTION>
 							<OPTION VALUE="19">Tri par mise &agrave; jour propri&eacute;taire invers&eacute;e</OPTION>
 							<OPTION VALUE="3">Tri par TSI </OPTION>
-							<OPTION VALUE="20">Tri par salaire réel</OPTION>
+							<OPTION VALUE="20">Tri par salaire r&eacute;el</OPTION>
 							<OPTION VALUE="21">Tri par salaire de base</OPTION>
               <OPTION VALUE="23">Tri par salaire de base invers&eacute;</OPTION>
               <OPTION VALUE="24">Tri par âge</OPTION>

--- a/dtn/interface/consulter/recherche_result.php
+++ b/dtn/interface/consulter/recherche_result.php
@@ -746,7 +746,7 @@ if(count($lstJ)==0) {
 					<TR>
 
 						<TD><B>Buteur :&nbsp; </B></TD><TD bgcolor="<?=$buteurColor?>"><?=$lstCarac[$lstJ[$j]["idButeur"]]["intituleCaracFR"]?><?php afficheLesPlus($lstJ[$j],"nbSemaineButeur"); ?></TD>
-						<TD><B>&nbsp; &nbsp; Coup franc :&nbsp; </B></TD><TD><?=$lstCarac[$lstJ[$j]["idPA"]]["intituleCaracFR"]?></TD>
+						<TD><B>&nbsp; &nbsp; Coup franc :&nbsp; </B></TD><TD><?=$lstCarac[$lstJ[$j]["idPA"]]["intituleCaracFR"]?><?php afficheLesPlus($lstJ[$j],"nbSemaineCoupFranc"); ?></TD>
 					</TR>
 					</TABLE>
 				</TD>

--- a/dtn/interface/consulter/recherche_result.php
+++ b/dtn/interface/consulter/recherche_result.php
@@ -128,7 +128,7 @@ $buteurColor = "#FFFFFF";
 $ordreDeTri=" ";
 
 $ordreDeTriTxt="";
-$typeExport="recherche"; // Utilisé pour export csv
+$typeExport="recherche"; // UtilisÃ© pour export csv
 
 switch($ht_posteAssigne){
 
@@ -268,7 +268,7 @@ switch($ordreDeTriNb){
 		break;
 	case "20":
 		$ordreDeTri=" ORDER BY salary DESC ";
-		$ordreDeTriTxt=" salaire réel";
+		$ordreDeTriTxt=" salaire rÃ©el";
 		break;				
 	case "21":
 		$ordreDeTri=" ORDER BY salaireDeBase DESC ";
@@ -287,12 +287,12 @@ switch($ordreDeTriNb){
 
   case "24":
 		$ordreDeTri=" ORDER BY ".$SqlAgeJoueur." ASC ,".$SqlJourJoueur." ASC ";
-		$ordreDeTriTxt=" âge";
+		$ordreDeTriTxt=" Ã¢ge";
 	break;
 	
 	case "25":
 		$ordreDeTri=" ORDER BY ".$SqlAgeJoueur." DESC ,".$SqlJourJoueur." DESC ";
-		$ordreDeTriTxt=" âge invers&eacute;";
+		$ordreDeTriTxt=" Ã¢ge invers&eacute;";
 	break;
 	
 	case "26":
@@ -381,8 +381,11 @@ if ($maxAge!="" ){
 }
 
 
-/***** Filtre sur la spécialité ****/
-if ($specialty!=-1 ){
+/***** Filtre sur la spÃ©cialitÃ© ****/
+if ($specialty==99){
+	$sql=$sql." AND (optionJoueur='1' || optionJoueur='2'|| optionJoueur='3' || optionJoueur='4' || optionJoueur='5' || optionJoueur='6' || optionJoueur='8')";
+	?><li> Avec n'importe quelle sp&eacute;cialit&eacute; <?php
+} else if ($specialty!=-1 ){
 	$sql=$sql." AND optionJoueur=".$specialty;
 	?><li> Avec comme sp&eacute;cialit&eacute; :<font color="#CC22DD"><?=$option[$specialty]["FR"]?></font><?php
 } 
@@ -489,16 +492,16 @@ if ($SkillType4!="" && ($SkillMin4!="" || $SkillMax4!="" )){
 
 $retour = $maBase->select("SELECT  count(*) as nb ".$sql);
 
-//ajout dans une variable des clauses FROM et WHERE avant que tout ne soit regroupé (Utilisé pour export csv) par jojoje86 le 22/07/09-->
+//ajout dans une variable des clauses FROM et WHERE avant que tout ne soit regroupÃ© (UtilisÃ© pour export csv) par jojoje86 le 22/07/09-->
 $laSelection=urlencode($sql);
 
 $nbjoueur=$retour[0]["nb"];
 $sql=$sqlreel.$sql.$ordreDeTri;
 
-// Extraction des 50 joueurs de la page (ou moins si page incomplète) pour transfert
-// à ficherecupchoix.php pour affichage de fiches résumé par lots
+// Extraction des 50 joueurs de la page (ou moins si page incomplÃ¨te) pour transfert
+// Ã  ficherecupchoix.php pour affichage de fiches rÃ©sumÃ© par lots
 // Dans ce cas $sql1=$sql et $ListeTotale=$lstJ
-// mais on conserve la routine pour modification rapide du nombre de fiches résumé à extraire 
+// mais on conserve la routine pour modification rapide du nombre de fiches rÃ©sumÃ© Ã  extraire 
 // Fireproofed le 05/11/2010
 // $sql1=$sql."	LIMIT ".$indexDeb.",50;";
 // $ListeTotale=$maBase->select($sql1);
@@ -509,7 +512,7 @@ $sql.="	LIMIT ".$indexDeb.",50;";
 
 $lstJ = $maBase->select($sql);
 
-$_SESSION['ListeFicheResume']=$lstJ //variable _SESSION pour transfert vers fiches résumé en lot - Fireproofed
+$_SESSION['ListeFicheResume']=$lstJ //variable _SESSION pour transfert vers fiches rÃ©sumÃ© en lot - Fireproofed
 
 
 //echo $sql;
@@ -593,14 +596,14 @@ if(count($lstJ)==0) {
 	       
 	       
     } // Fin Si il y a plus de 1 page
-} // Fin else (= au moins 1 joueur trouvé)
+} // Fin else (= au moins 1 joueur trouvÃ©)
 ?>
 				<br>
 				<!--// Ajout du liens permetant l'export CSV par jojoje86 le 22/07/09-->
-				<!--// Ce liens n'est visible que si le niveau d'accès est suffisant par jojoje86 le 25/07/09-->
+				<!--// Ce liens n'est visible que si le niveau d'accÃ¨s est suffisant par jojoje86 le 25/07/09-->
 <?php
 				if ($sesUser["idNiveauAcces"]==1 || $sesUser["idNiveauAcces"]==2 || $sesUser["idNiveauAcces"]==4)
-        //si admin, DTN+ ou sélectionneur alors autoriser export CSV et fiche résumé globale
+        //si admin, DTN+ ou sÃ©lectionneur alors autoriser export CSV et fiche rÃ©sumÃ© globale
 				{
 ?>
 
@@ -609,7 +612,7 @@ if(count($lstJ)==0) {
               <td valign="middle">Export Excel :&nbsp;</td>
               <td valign="middle"><a href="../outils/ExportCsv.php?typeExport=<?=$typeExport?>&laSelection=<?=$laSelection?>&ordre=<?=$ordreDeTri?>"><img border=1 src="../images/icone-excel.jpg" title="Exporter le r&eacute;sultat de ma recherche sur Excel"></a></td>
               
-              <!-- Rajout export vers fiches résumé -->
+              <!-- Rajout export vers fiches rÃ©sumÃ© -->
               <!-- Fireproofed le 05/11/2010 -->
               
               <td valign="middle">
@@ -625,7 +628,7 @@ if(count($lstJ)==0) {
 <?php
 				} else { 
         if ($sesUser["idNiveauAcces"]==3 and ($sesUser["idPosition_fk"]==$ht_posteAssigne or $sesUser["idPosition_fk"]==6 or $sesUser["idPosition_fk"]==0))
-        //Si DTN et secteur DTN=secteur recherché ou si DTN tous secteurs alors autoriser fiche résumé globale
+        //Si DTN et secteur DTN=secteur recherchÃ© ou si DTN tous secteurs alors autoriser fiche rÃ©sumÃ© globale
         //Fireproofed le 23/11/2010
         {
 ?>        
@@ -786,7 +789,7 @@ if(count($lstJ)==0) {
 				<?=$nbjoueur?>&nbsp;joueurs ont &eacute;t&eacute; trouv&eacute;s.&nbsp;<br> 
     <?php			
 
-} // Fin else (= au moins 1 joueur trouvé)
+} // Fin else (= au moins 1 joueur trouvÃ©)
 ?>
 				</TD>
 			</TR>

--- a/dtn/interface/consulter/topsPotentiels.php
+++ b/dtn/interface/consulter/topsPotentiels.php
@@ -396,7 +396,7 @@ $param2="$nb_players";
                     <?=$l["idDefense"]?><?php afficheLesPlus($l,"nbSemaineDefense"); ?> 
                       </div></td>
                     <td > <div align="center"> 
-                    <?=$l["idPA"]?> 
+                    <?=$l["idPA"]?><?php afficheLesPlus($l,"nbSemaineCoupFranc"); ?>  
                       </div></td>
                     <td > <div align="center"> 
                     <?=$note?> 

--- a/dtn/interface/consulter/topsPublics.php
+++ b/dtn/interface/consulter/topsPublics.php
@@ -479,7 +479,7 @@ for ($lstnb=16;$lstnb<27;$lstnb++ ){
                     <?=$l["idDefense"]?><?php afficheLesPlus($l,"nbSemaineDefense"); ?> 
                       </div></td>
                     <td > <div align="center"> 
-                    <?=$l["idPA"]?> 
+                    <?=$l["idPA"]?> <?php afficheLesPlus($l,"nbSemaineCoupFranc"); ?>
                       </div></td>
 
 

--- a/dtn/interface/equipe/dtn.php
+++ b/dtn/interface/equipe/dtn.php
@@ -69,8 +69,8 @@ if(!isset($nbJoueurs)) $nbJoueurs ="false";
                   <td height="20"><input name="loginAdmin" type="text" id="loginAdmin"></td>
                 </tr>
                 <tr>
-                  <td height="20">Mot de passe</td>
-                  <td height="20"><input name="passAdmin" type="text" id="passAdmin"></td>
+                  <td height="20">Mail</td>
+                  <td height="20"><input name="emailAdmin" type="text" id="emailAdmin"></td>
                 </tr>
                 <tr>
                   <td height="10">ID User Hattrick</td>
@@ -142,7 +142,7 @@ if(!isset($nbJoueurs)) $nbJoueurs ="false";
               <tr>
                 <td width="151" onClick = "chgTri('loginAdmin','<?=$sens?>')"><div align="left"><strong>&nbsp;Login</strong></div></td>
                 <td width="1" bgcolor="#000000"></td>
-                <td width="135"onClick = "chgTri('passAdmin','<?=$sens?>')"><strong>&nbsp;Code d'acc&egrave;s</strong></td>
+                <td width="135"onClick = "chgTri('emailAdmin','<?=$sens?>')"><strong>&nbsp;Mail</strong></td>
                 <td width="1" bgcolor="#000000"><strong><img src="../images/spacer.gif" width="1" height="1"></strong></td>
                 <td width="119"onClick = "chgTri('intitulePosition','<?=$sens?>')"><div align="center"><strong>Cat&eacute;gorie</strong></div></td>
                 <td width="1" bgcolor="#000000"><strong><img src="../images/spacer.gif" width="1" height="1"></strong></td>
@@ -178,7 +178,7 @@ if(!isset($nbJoueurs)) $nbJoueurs ="false";
                <tr bgcolor="<?=$bgcolor?>">
                 <td>&nbsp;<a href = "fiche.php?dtn=<?=$l["idAdmin"]?>"><?=$l["loginAdmin"]?></a></td>
                 <td width="1" bgcolor="#000000"></td>
-                <td>&nbsp;<?=$l["passAdmin"]?></td>
+                <td>&nbsp;<?=$l["emailAdmin"]?></td>
                 <td width="1" bgcolor="#000000"></td>
                 <td align="center">&nbsp;<?=$l["intitulePosition"]?></td>
                 <td width="1" bgcolor="#000000"></td>

--- a/dtn/interface/equipe/editselec.php
+++ b/dtn/interface/equipe/editselec.php
@@ -31,7 +31,7 @@ switch($sesUser["idNiveauAcces"]){
 }
 
 
-?><title>Sélectionneurs</title>
+?><title>SÃ©lectionneurs</title>
 <table width="700" border="1" align="center" cellpadding="0" cellspacing="0" bordercolor="#000000">
   <tr><br/><br/><td height="20" bgcolor="#000000"><div align="center"><font color="#FFFFFF">Gestion des s&eacute;lectionneurs</font></div>
             </td>
@@ -43,7 +43,7 @@ switch($sesUser["idNiveauAcces"]){
     if (isset($_POST["loginAdmin"]) && isset($_POST["passAdmin"]) && isset($_POST["idAdminHT"]) && isset($_POST["emailAdmin"])) {
         $req = $conn->prepare('UPDATE ht_admin SET passAdmin = :nvpass, idAdminHT = :nvid, emailAdmin = :nvmail WHERE loginAdmin = :login');
         $req->execute(array(
-            'nvpass' => $_POST["passAdmin"],
+            'nvpass' => sha1($_POST["passAdmin"]),
             'nvid' => $_POST["idAdminHT"],
             'nvmail' => $_POST["emailAdmin"],
             'login' => $_POST["loginAdmin"]

--- a/dtn/interface/equipe/modifAdmin.php
+++ b/dtn/interface/equipe/modifAdmin.php
@@ -54,7 +54,7 @@ $infDTN = getDTN($idAdmin);
                 </tr>
                 <tr>
                   <td height="20">Mot de passe</td>
-                  <td height="20"><input name="passAdmin" type="text" id="passAdmin" value = "<?=$infDTN["passAdmin"]?>"></td>
+                  <td height="20"><input name="passAdmin" type="text" id="passAdmin" ></td>
                 </tr>
                 <tr>
                   <td height="10">ID Hattrick</td>

--- a/dtn/interface/equipe/superviseur.php
+++ b/dtn/interface/equipe/superviseur.php
@@ -66,8 +66,8 @@ if(!isset($sens)) $sens = "ASC";
                   <td height="20"><input name="loginAdmin" type="text" id="loginAdmin"></td>
                 </tr>
                 <tr>
-                  <td height="20">Mot de passe</td>
-                  <td height="20"><input name="passAdmin" type="text" id="passAdmin"></td>
+                  <td height="20">Mail</td>
+                  <td height="20"><input name="emailAdmin" type="text" id="emailAdmin"></td>
                 </tr>
                 <tr>
                   <td height="10">ID User Hattrick</td>
@@ -138,7 +138,7 @@ if(!isset($sens)) $sens = "ASC";
               <tr>
                 <td width="151" onClick = "chgTri('loginAdmin','<?=$sens?>')"><div align="left"><strong>&nbsp;Login</strong></div></td>
                 <td width="1" bgcolor="#000000"><strong><img src="../images/spacer.gif" width="1" height="1"></strong></td>
-                <td width="135"onClick = "chgTri('passAdmin','<?=$sens?>')"><strong>&nbsp;Code d'acc&egrave;s</strong></td>
+                <td width="135"onClick = "chgTri('emailAdmin','<?=$sens?>')"><strong>&nbsp;Mail</strong></td>
                 <td width="1" bgcolor="#000000"><strong><img src="../images/spacer.gif" width="1" height="1"></strong></td>
                 <td width="119"onClick = "chgTri('intitulePosition','<?=$sens?>')"><div align="center"><strong>Cat&eacute;gorie</strong></div></td>
                 <td width="1" bgcolor="#000000"><strong><img src="../images/spacer.gif" width="1" height="1"></strong></td>
@@ -174,7 +174,7 @@ if(!isset($sens)) $sens = "ASC";
               <tr bgcolor="<?=$bgcolor?>">
                 <td>&nbsp;<a href = "fiche.php?dtn=<?=$l["idAdmin"]?>"><?=$l["loginAdmin"]?></a></td>
                 <td width="1" bgcolor="#000000"><img src="../images/spacer.gif" width="1" height="1"></td>
-                <td>&nbsp;<?=$l["passAdmin"]?></td>
+                <td>&nbsp;<?=$l["emailAdmin"]?></td>
                 <td width="1" bgcolor="#000000"><img src="../images/spacer.gif" width="1" height="1"></td>
                 <td>&nbsp;<?=$l["intitulePosition"]?></td>
                 <td width="1" bgcolor="#000000"><img src="../images/spacer.gif" width="1" height="1"></td>

--- a/dtn/interface/form.php
+++ b/dtn/interface/form.php
@@ -90,7 +90,7 @@ case "reactivAdmin":
 
 case "modifAdmin";
 
-	$sql = $conn->exec("UPDATE ht_admin SET   loginAdmin = '".$loginAdmin."', passAdmin  ='".$passAdmin."',idAdminHT= '".$idAdminHT."' ,
+	$sql = $conn->exec("UPDATE ht_admin SET   loginAdmin = '".$loginAdmin."', passAdmin  ='".sha1($passAdmin)."',idAdminHT= '".$idAdminHT."' ,
                                          emailAdmin  = '".$emailAdmin."' ,idNiveauAcces_fk = '".$idNiveauAcces_fk."'  ,  idPosition_fk  = '".$idPosition_fk."' WHERE idAdmin = '".$idAdmin."'");
 
 	header("location: equipe/$from.php?msg=L administrateur a bien ete modifie");
@@ -109,7 +109,7 @@ case "ajoutAdmin":
 			break;
 		}
 
-		$conn->exec("UPDATE ht_admin SET loginAdmin = '".$loginAdmin."', passAdmin  ='".$passAdmin."',idAdminHT= '".$idAdminHT."' ,
+		$conn->exec("UPDATE ht_admin SET loginAdmin = '".$loginAdmin."', passAdmin  ='".sha1($passAdmin)."',idAdminHT= '".$idAdminHT."' ,
 					emailAdmin  = '".$emailAdmin."' ,idNiveauAcces_fk = '".$idNiveauAcces_fk."'  ,  idPosition_fk  = '".$idPosition_fk."', affAdmin=1 WHERE idAdmin = '".$row["idAdmin"]."'");
 
 		header("location: equipe/$from.php?msg=L administrateur a bien ete modifie");
@@ -117,7 +117,7 @@ case "ajoutAdmin":
 	else{
 
 		$sql = "INSERT INTO ht_admin (loginAdmin, passAdmin, idAdminHT, emailAdmin, idNiveauAcces_fk , idPosition_fk, affAdmin)";
-		$sql .= "VALUES                          ('$loginAdmin', '$passAdmin', '$idAdminHT', '$emailAdmin', $idNiveauAcces_fk, '$idPosition_fk', 1)";
+		$sql .= "VALUES                          ('$loginAdmin', '".sha1($passAdmin)."', '$idAdminHT', '$emailAdmin', $idNiveauAcces_fk, '$idPosition_fk', 1)";
 		$req = $conn->exec($sql);
 
 		header("location: equipe/$from.php?msg=Administrateur bien ajoute a la liste");

--- a/dtn/interface/form.php
+++ b/dtn/interface/form.php
@@ -820,6 +820,12 @@ case "addNiveau":
 			break;
 		case "7":
 			$nomNiveau=" Coup Franc ";
+			if ($niveauInitial < $niveau) {
+			$sql = "update $tbl_entrainement set nbSemaineCoupFranc  = 0 where idJoueur_fk = $idJoueur";
+            } else {
+            $sql = "update $tbl_entrainement set nbSemaineCoupFranc  = 99 where idJoueur_fk = $idJoueur";
+            }
+			$req=$conn->exec($sql);
 			$updatedate_modif_effectif="on";
 			break;   
 		case "8":
@@ -906,7 +912,12 @@ case "updateTraining":
 		$updatedate_modif_effectif="on";
 	}
 	if($infJoueur["nbSemaineDefense"]!= $_POST["nbSemaineDefense"]){
-		$msg  = $msg." Modif semaines defense (".$infJoueur["nbSemaineDefense"]." ->+".$_POST["nbSemaineDefense"].")  ";
+		$msg  = $msg." Modif semaines d&eacute;fense (".$infJoueur["nbSemaineDefense"]." ->+".$_POST["nbSemaineDefense"].")  ";
+		$updateDateDerniereModiff="on";	
+		$updatedate_modif_effectif="on";
+	}
+	if($infJoueur["nbSemaineCoupFranc"]!= $_POST["nbSemaineCoupFranc"]){
+		$msg  = $msg." Modif semaines coup franc (".$infJoueur["nbSemaineCoupFranc"]." ->+".$_POST["nbSemaineCoupFranc"].")  ";
 		$updateDateDerniereModiff="on";	
 		$updatedate_modif_effectif="on";
 	}
@@ -918,6 +929,7 @@ case "updateTraining":
          nbSemaineGardien = \"".$_POST["nbSemaineGardien"]."\",
          nbSemainePasses = \"".$_POST["nbSemainePasses"]."\",
          nbSemaineDefense = \"".$_POST["nbSemaineDefense"]."\"
+         nbSemaineCoupFranc = \"".$_POST["nbSemaineCoupFranc"]."\"
          WHERE idJoueur_fk = ".$_POST["idJoueur_fk"]."");
     $req = $conn->exec($sql);
 

--- a/dtn/interface/form.php
+++ b/dtn/interface/form.php
@@ -718,7 +718,7 @@ case "coeffSelectionneur":
 
 case "chgInfoPerso":
 
-	$sql = "UPDATE ht_admin SET loginAdmin = '".$login."', passAdmin = '".$mdp."', emailAdmin = '".$email."' WHERE idAdmin = '".$sesUser["idAdmin"]."'";
+	$sql = "UPDATE ht_admin SET loginAdmin = '".$login."', passAdmin = '".sha1($mdp)."', emailAdmin = '".$email."' WHERE idAdmin = '".$sesUser["idAdmin"]."'";
 	$req = $conn->exec($sql);
 
 	header("location: settings.php?modperso=ok&affinfoPerso=1");

--- a/dtn/interface/form.php
+++ b/dtn/interface/form.php
@@ -90,10 +90,14 @@ case "reactivAdmin":
 
 case "modifAdmin";
 
+if (isset($passAdmin) && $passAdmin !="") {
 	$sql = $conn->exec("UPDATE ht_admin SET   loginAdmin = '".$loginAdmin."', passAdmin  ='".sha1($passAdmin)."',idAdminHT= '".$idAdminHT."' ,
                                          emailAdmin  = '".$emailAdmin."' ,idNiveauAcces_fk = '".$idNiveauAcces_fk."'  ,  idPosition_fk  = '".$idPosition_fk."' WHERE idAdmin = '".$idAdmin."'");
 
 	header("location: equipe/$from.php?msg=L administrateur a bien ete modifie");
+} else {
+	header("location: equipe/$from.php?msg=L administrateur n a pas ete modifie");
+}
 	break;
 
 case "ajoutAdmin":
@@ -718,10 +722,13 @@ case "coeffSelectionneur":
 
 case "chgInfoPerso":
 
+if (isset($mdp) && isset($mdp2) && $mdp !="" && $mdp==$mdp2) {
 	$sql = "UPDATE ht_admin SET loginAdmin = '".$login."', passAdmin = '".sha1($mdp)."', emailAdmin = '".$email."' WHERE idAdmin = '".$sesUser["idAdmin"]."'";
 	$req = $conn->exec($sql);
-
-	header("location: settings.php?modperso=ok&affinfoPerso=1");
+    header("location: settings.php?modperso=ok&affinfoPerso=1");
+} else {
+    header("location: settings.php?modperso=ohno&affinfoPerso=1");
+}
 	break;
 
 

--- a/dtn/interface/form.php
+++ b/dtn/interface/form.php
@@ -912,7 +912,7 @@ case "updateTraining":
 		$updatedate_modif_effectif="on";
 	}
 	if($infJoueur["nbSemaineDefense"]!= $_POST["nbSemaineDefense"]){
-		$msg  = $msg." Modif semaines d&eacute;fense (".$infJoueur["nbSemaineDefense"]." ->+".$_POST["nbSemaineDefense"].")  ";
+		$msg  = $msg." Modif semaines defense (".$infJoueur["nbSemaineDefense"]." ->+".$_POST["nbSemaineDefense"].")  ";
 		$updateDateDerniereModiff="on";	
 		$updatedate_modif_effectif="on";
 	}

--- a/dtn/interface/form.php
+++ b/dtn/interface/form.php
@@ -928,7 +928,7 @@ case "updateTraining":
          nbSemaineButeur = \"".$_POST["nbSemaineButeur"]."\",
          nbSemaineGardien = \"".$_POST["nbSemaineGardien"]."\",
          nbSemainePasses = \"".$_POST["nbSemainePasses"]."\",
-         nbSemaineDefense = \"".$_POST["nbSemaineDefense"]."\"
+         nbSemaineDefense = \"".$_POST["nbSemaineDefense"]."\",
          nbSemaineCoupFranc = \"".$_POST["nbSemaineCoupFranc"]."\"
          WHERE idJoueur_fk = ".$_POST["idJoueur_fk"]."");
     $req = $conn->exec($sql);

--- a/dtn/interface/formJoueurDirect.php
+++ b/dtn/interface/formJoueurDirect.php
@@ -1,0 +1,11 @@
+<?php
+ini_set('display_errors','1');
+if (isset($_GET["idJoueurHT"]) && $_GET["idJoueurHT"] !="") {
+        $idHattrickJoueur = (int)$_GET["idJoueurHT"];
+        if (!empty($idHattrickJoueur)) {
+            header("location: ".$url."/dtn/interface/joueurs/fiche.php?htid=".$idHattrickJoueur);
+            exit;
+        } 
+}
+header("location: ".$url."/dtn/interface/joueurs/verifPlayer.php");
+?>

--- a/dtn/interface/includes/serviceJoueur.php
+++ b/dtn/interface/includes/serviceJoueur.php
@@ -1095,8 +1095,29 @@ function validateMinimaPlayer($player,$todaySeason)
 		}
 	}
 	
-	if (!$reqValid) {
-		return -1;
+	if ($reqValid) {
+		 $secteur ==0;
+		if ($player["idGardien"] >=7) {
+			$secteur==1;
+		}
+		if (($player["idDefense"] >$player["idConstruction"]+1) && ($player["idDefense"] >$player["idAilier"]+1) && ($player["idDefense"] >$player["idButeur"]+1)) {
+			// défense
+			$secteur==2;
+		} else {
+			// Ailier
+			if (($player["idAilier"] >$player["idConstruction"]+1) && ($player["idAilier"] >$player["idButeur"]+1)) {
+				$secteur==3;
+			} else {
+				if ($player["idConstruction"] >$player["idButeur"]+1) {
+					//milieu
+					$secteur==4;
+				} else {
+					// buteur
+					$secteur==5;
+				}
+			}
+		}
+		return $secteur;
 	} else {
 		//** ATTENTION! dans ce cas, les joueurs sont tous acceptes, soit la semaine n'est pas valide (>16 ou negative)
 		return -2;

--- a/dtn/interface/includes/serviceJoueur.php
+++ b/dtn/interface/includes/serviceJoueur.php
@@ -143,6 +143,7 @@ function getTousJoueurSQL(){
         nbSemaineGardien,
         nbSemainePasses,
         nbSemaineDefense,
+        nbSemaineCoupFranc,
         valeurEnCours,
         commentaire,
         ht_clubs.nomClub,
@@ -487,6 +488,7 @@ function calculNote($joueur){
   $niveauAilier=$joueur["idAilier"] + $joueur["nbSemaineAilier"] * 0.1;
   $niveauAttaquant=$joueur["idButeur"] + $joueur["nbSemaineButeur"] * 0.1;
   $niveauPasse=$joueur["idPasse"] + $joueur["nbSemainePasses"] * 0.1;
+  $niveauCF=$joueur["idPA"] + $joueur["nbSemaineCoupFranc"] * 0.1;
   $xp=$joueur["idExperience_fk"];
 
   // Gardien
@@ -648,6 +650,7 @@ function calculNotePotentiel($joueur){
   $semainesAilier=$joueur["nbSemaineAilier"];
   $semainesAttaquant=$joueur["nbSemaineButeur"];
   $semainesPasse=$joueur["nbSemainePasses"];
+  $semainesCF=$joueur["nbSemaineCoupFranc"];
   
 
   $semainesGKPotentiel=$semainesGK+$nbSemRestant;
@@ -656,6 +659,7 @@ function calculNotePotentiel($joueur){
   $semainesAilierPotentiel=$semainesAilier+$nbSemRestant;
   $semainesAttaquantPotentiel=$semainesAttaquant+$nbSemRestant;
   $semainesPassePotentiel=$semainesPasse+$nbSemRestant;
+  $semainesCFPotentiel=$semainesCF+$nbSemRestant;
   
   //$niveauGK=$infJ["idGardien"] + ($semainesGK/$tabVitesses["Gardien"][$infJ["ageJoueur"]]);
   $niveauDef=$joueur["idDefense"] + ($semainesDef/$tabVitesses["Defense"][$joueur["ageJoueur"]]);
@@ -1135,7 +1139,8 @@ function majCaracJoueur($joueur){
       nbSemaineButeur  = "'.$joueur["nbSemaineButeur"].'",
       nbSemaineGardien = "'.$joueur["nbSemaineGardien"].'",
       nbSemainePasses= "'.$joueur["nbSemainePasses"].'",
-      nbSemaineDefense = "'.$joueur["nbSemaineDefense"].'"
+      nbSemaineDefense = "'.$joueur["nbSemaineDefense"].'",
+      nbSemaineCoupFranc = "'.$joueur["nbSemaineCoupFranc"].'"
       WHERE idJoueur_fk = "'.$joueur["idJoueur"].'"';
     $result= $conn->exec($sql);
     
@@ -1542,6 +1547,7 @@ function ajoutJoueur($ht_user,$role_user,$joueurHT,$joueurDTN,$posteAssigne) {
     $joueurNote["nbSemaineDefense"] =  0.0;
     $joueurNote["nbSemaineButeur"] =  0.0;
     $joueurNote["nbSemaineAilier"] =  0.0;
+    $joueurNote["nbSemaineCoupFranc"] =  0.0;
     $joueurNote["valeurEnCours"] = $joueurHT['tsi'];
     
     $joueurNote["optionJoueur"] = $joueurHT["optionJoueur"];
@@ -1844,6 +1850,7 @@ function updateEntrainement($entrainement) {
   if (isset($entrainement['nbSemaineGardien']))       {$sql.="nbSemaineGardien = '".$entrainement['nbSemaineGardien']."',";}
   if (isset($entrainement['nbSemainePasses']))        {$sql.="nbSemainePasses = '".$entrainement['nbSemainePasses']."',";}
   if (isset($entrainement['nbSemaineDefense']))       {$sql.="nbSemaineDefense = '".$entrainement['nbSemaineDefense']."',";}
+  if (isset($entrainement['nbSemaineCoupFranc']))       {$sql.="nbSemaineCoupFranc = '".$entrainement['nbSemaineCoupFranc']."',";}
   if (isset($entrainement['valeurEnCours']))          {$sql.="valeurEnCours = '".$entrainement['valeurEnCours']."',";}
   $sql=substr($sql,0,strlen($sql)-1);
   $sql.=" WHERE idJoueur_fk  = ".$entrainement["idJoueur_fk"];
@@ -2153,6 +2160,11 @@ function majJoueur($ht_user,$role_user,$joueurHT,$joueurDTN){
 					$update_joueur['idPA']=$joueurHT['idPA'];
 					$resMAJ['HTML'].=' CF: '.$joueurDTN["idPA"].'-&gt; '.$joueurHT['idPA'].'<br>' ;
 					$histoModifMsg .=' CoupFranc: '.$joueurDTN['idPA'].' -> '.$joueurHT['idPA'];
+                    if ($joueurDTN['idPA']>$joueurHT['idPA']) {
+					$update_joueur_entrainement['nbSemaineCoupFranc']=99;
+                    } else {
+                    $update_joueur_entrainement['nbSemaineCoupFranc']=0;
+                    }
 					$joueurDTN["idPA"]=$joueurHT['idPA'];
 					$recalcul_note=true;
 					$update_joueur['date_modif_effectif']=date('Y-m-d');
@@ -2186,6 +2198,7 @@ function majJoueur($ht_user,$role_user,$joueurHT,$joueurDTN){
 				if (isset($update_joueur_entrainement["nbSemaineDefense"]))       {$joueurNote["nbSemaineDefense"]      = $update_joueur_entrainement["nbSemaineDefense"];      } else {$joueurNote["nbSemaineDefense"]       = $joueurDTN["nbSemaineDefense"];}
 				if (isset($update_joueur_entrainement["nbSemaineButeur"]))        {$joueurNote["nbSemaineButeur"]       = $update_joueur_entrainement["nbSemaineButeur"];       } else {$joueurNote["nbSemaineButeur"]        = $joueurDTN["nbSemaineButeur"];}
 				if (isset($update_joueur_entrainement["nbSemaineAilier"]))        {$joueurNote["nbSemaineAilier"]       = $update_joueur_entrainement["nbSemaineAilier"];       } else {$joueurNote["nbSemaineAilier"]        = $joueurDTN["nbSemaineAilier"];}
+				if (isset($update_joueur_entrainement["nbSemaineCoupFranc"]))        {$joueurNote["nbSemaineCoupFranc"]       = $update_joueur_entrainement["nbSemaineCoupFranc"];       } else {$joueurNote["nbSemaineCoupFranc"]        = $joueurDTN["nbSemaineCoupFranc"];}
 
 				$joueurNote["valeurEnCours"] = $joueurDTN["valeurEnCours"];
 				

--- a/dtn/interface/includes/serviceJoueur.php
+++ b/dtn/interface/includes/serviceJoueur.php
@@ -1067,6 +1067,7 @@ function validateMinimaPlayer($player,$todaySeason)
 {
 	require($_SERVER['DOCUMENT_ROOT'].'/dtn/interface/includes/nomTables.inc.php');
 	global $conn;
+        global $secteur;
 
 	$ageetjours = ageetjour($player["datenaiss"]);
 	$tabage = explode(" - ",$ageetjours);

--- a/dtn/interface/includes/serviceJoueur.php
+++ b/dtn/interface/includes/serviceJoueur.php
@@ -1119,7 +1119,7 @@ function validateMinimaPlayer($player,$todaySeason)
 		}
 	} else {
 		//** joueur ne rempli pas les pré-requis, on ne l'enregistre pas
-		$secteur== -1;
+		$secteur== -1; 
 	}
 	return $secteur;
 }

--- a/dtn/interface/includes/serviceJoueur.php
+++ b/dtn/interface/includes/serviceJoueur.php
@@ -143,7 +143,6 @@ function getTousJoueurSQL(){
         nbSemaineGardien,
         nbSemainePasses,
         nbSemaineDefense,
-        nbSemaineCoupFranc,
         valeurEnCours,
         commentaire,
         ht_clubs.nomClub,
@@ -488,7 +487,6 @@ function calculNote($joueur){
   $niveauAilier=$joueur["idAilier"] + $joueur["nbSemaineAilier"] * 0.1;
   $niveauAttaquant=$joueur["idButeur"] + $joueur["nbSemaineButeur"] * 0.1;
   $niveauPasse=$joueur["idPasse"] + $joueur["nbSemainePasses"] * 0.1;
-  $niveauCF=$joueur["idPA"] + $joueur["nbSemaineCoupFranc"] * 0.1;
   $xp=$joueur["idExperience_fk"];
 
   // Gardien
@@ -650,7 +648,6 @@ function calculNotePotentiel($joueur){
   $semainesAilier=$joueur["nbSemaineAilier"];
   $semainesAttaquant=$joueur["nbSemaineButeur"];
   $semainesPasse=$joueur["nbSemainePasses"];
-  $semainesCF=$joueur["nbSemaineCoupFranc"];
   
 
   $semainesGKPotentiel=$semainesGK+$nbSemRestant;
@@ -659,7 +656,6 @@ function calculNotePotentiel($joueur){
   $semainesAilierPotentiel=$semainesAilier+$nbSemRestant;
   $semainesAttaquantPotentiel=$semainesAttaquant+$nbSemRestant;
   $semainesPassePotentiel=$semainesPasse+$nbSemRestant;
-  $semainesCFPotentiel=$semainesCF+$nbSemRestant;
   
   //$niveauGK=$infJ["idGardien"] + ($semainesGK/$tabVitesses["Gardien"][$infJ["ageJoueur"]]);
   $niveauDef=$joueur["idDefense"] + ($semainesDef/$tabVitesses["Defense"][$joueur["ageJoueur"]]);
@@ -1071,7 +1067,6 @@ function validateMinimaPlayer($player,$todaySeason)
 {
 	require($_SERVER['DOCUMENT_ROOT'].'/dtn/interface/includes/nomTables.inc.php');
 	global $conn;
-        global $secteur;
 
 	$ageetjours = ageetjour($player["datenaiss"]);
 	$tabage = explode(" - ",$ageetjours);
@@ -1101,7 +1096,7 @@ function validateMinimaPlayer($player,$todaySeason)
 	}
 	
 	if ($reqValid) {
-		 $secteur ==0;
+		$secteur ==0;
 		if ($player["idGardien"] >=7) {
 			$secteur==1;
 		}
@@ -1122,13 +1117,11 @@ function validateMinimaPlayer($player,$todaySeason)
 				}
 			}
 		}
-		return $secteur;
 	} else {
-		//** ATTENTION! dans ce cas, les joueurs sont tous acceptes, soit la semaine n'est pas valide (>16 ou negative)
-		return -2;
+		//** joueur ne rempli pas les pré-requis, on ne l'enregistre pas
+		$secteur== -1;
 	}
-	
-	return $result;
+	return $secteur;
 }
 
 
@@ -1161,8 +1154,7 @@ function majCaracJoueur($joueur){
       nbSemaineButeur  = "'.$joueur["nbSemaineButeur"].'",
       nbSemaineGardien = "'.$joueur["nbSemaineGardien"].'",
       nbSemainePasses= "'.$joueur["nbSemainePasses"].'",
-      nbSemaineDefense = "'.$joueur["nbSemaineDefense"].'",
-      nbSemaineCoupFranc = "'.$joueur["nbSemaineCoupFranc"].'"
+      nbSemaineDefense = "'.$joueur["nbSemaineDefense"].'"
       WHERE idJoueur_fk = "'.$joueur["idJoueur"].'"';
     $result= $conn->exec($sql);
     
@@ -1569,7 +1561,6 @@ function ajoutJoueur($ht_user,$role_user,$joueurHT,$joueurDTN,$posteAssigne) {
     $joueurNote["nbSemaineDefense"] =  0.0;
     $joueurNote["nbSemaineButeur"] =  0.0;
     $joueurNote["nbSemaineAilier"] =  0.0;
-    $joueurNote["nbSemaineCoupFranc"] =  0.0;
     $joueurNote["valeurEnCours"] = $joueurHT['tsi'];
     
     $joueurNote["optionJoueur"] = $joueurHT["optionJoueur"];
@@ -1872,7 +1863,6 @@ function updateEntrainement($entrainement) {
   if (isset($entrainement['nbSemaineGardien']))       {$sql.="nbSemaineGardien = '".$entrainement['nbSemaineGardien']."',";}
   if (isset($entrainement['nbSemainePasses']))        {$sql.="nbSemainePasses = '".$entrainement['nbSemainePasses']."',";}
   if (isset($entrainement['nbSemaineDefense']))       {$sql.="nbSemaineDefense = '".$entrainement['nbSemaineDefense']."',";}
-  if (isset($entrainement['nbSemaineCoupFranc']))       {$sql.="nbSemaineCoupFranc = '".$entrainement['nbSemaineCoupFranc']."',";}
   if (isset($entrainement['valeurEnCours']))          {$sql.="valeurEnCours = '".$entrainement['valeurEnCours']."',";}
   $sql=substr($sql,0,strlen($sql)-1);
   $sql.=" WHERE idJoueur_fk  = ".$entrainement["idJoueur_fk"];
@@ -2182,11 +2172,6 @@ function majJoueur($ht_user,$role_user,$joueurHT,$joueurDTN){
 					$update_joueur['idPA']=$joueurHT['idPA'];
 					$resMAJ['HTML'].=' CF: '.$joueurDTN["idPA"].'-&gt; '.$joueurHT['idPA'].'<br>' ;
 					$histoModifMsg .=' CoupFranc: '.$joueurDTN['idPA'].' -> '.$joueurHT['idPA'];
-                    if ($joueurDTN['idPA']>$joueurHT['idPA']) {
-					$update_joueur_entrainement['nbSemaineCoupFranc']=99;
-                    } else {
-                    $update_joueur_entrainement['nbSemaineCoupFranc']=0;
-                    }
 					$joueurDTN["idPA"]=$joueurHT['idPA'];
 					$recalcul_note=true;
 					$update_joueur['date_modif_effectif']=date('Y-m-d');
@@ -2220,7 +2205,6 @@ function majJoueur($ht_user,$role_user,$joueurHT,$joueurDTN){
 				if (isset($update_joueur_entrainement["nbSemaineDefense"]))       {$joueurNote["nbSemaineDefense"]      = $update_joueur_entrainement["nbSemaineDefense"];      } else {$joueurNote["nbSemaineDefense"]       = $joueurDTN["nbSemaineDefense"];}
 				if (isset($update_joueur_entrainement["nbSemaineButeur"]))        {$joueurNote["nbSemaineButeur"]       = $update_joueur_entrainement["nbSemaineButeur"];       } else {$joueurNote["nbSemaineButeur"]        = $joueurDTN["nbSemaineButeur"];}
 				if (isset($update_joueur_entrainement["nbSemaineAilier"]))        {$joueurNote["nbSemaineAilier"]       = $update_joueur_entrainement["nbSemaineAilier"];       } else {$joueurNote["nbSemaineAilier"]        = $joueurDTN["nbSemaineAilier"];}
-				if (isset($update_joueur_entrainement["nbSemaineCoupFranc"]))        {$joueurNote["nbSemaineCoupFranc"]       = $update_joueur_entrainement["nbSemaineCoupFranc"];       } else {$joueurNote["nbSemaineCoupFranc"]        = $joueurDTN["nbSemaineCoupFranc"];}
 
 				$joueurNote["valeurEnCours"] = $joueurDTN["valeurEnCours"];
 				

--- a/dtn/interface/index.php
+++ b/dtn/interface/index.php
@@ -47,7 +47,7 @@ if (isset($_POST['nomForm']) && $_POST['nomForm']=='formConnexion') {
             FROM  $tbl_admin, 
                   $tbl_niveauAcces
             WHERE $tbl_admin.loginAdmin = '".$_POST['login']."' 
-            AND   $tbl_admin.passAdmin = '".$_POST['password']."' 
+            AND   $tbl_admin.passAdmin = '".sha1($_POST['password'])."' 
             AND   $tbl_admin.idNiveauAcces_fk = $tbl_niveauAcces.idNiveauAcces";
     
     $req  = $conn->query($sql);

--- a/dtn/interface/joueurs/ajouteraiiihelp.php
+++ b/dtn/interface/joueurs/ajouteraiiihelp.php
@@ -288,6 +288,10 @@ require("../menu/menuJoueur.php");
 			case "passe":
 			$nbSemaineE = '(+'.$infJ["nbSemainePasses"].')';
 			break;
+		
+			case "coup franc":
+			$nbSemaineE = '(+'.$infJ["nbSemaineCoupFranc"].')';
+			break;
 	
 			default:
 			$nbSemaineE ="";

--- a/dtn/interface/joueurs/fiche.php
+++ b/dtn/interface/joueurs/fiche.php
@@ -449,6 +449,10 @@ if ($datemaj >$mkday -$huit){
                 case "passe":
                 $nbSemaineE = '(+'.$joueurDTN["nbSemainePasses"].')';
                 break;
+              
+                case "coup franc":
+                $nbSemaineE = '(+'.$joueurDTN["nbSemaineCoupFranc"].')';
+                break;
             
                 default:
                 $nbSemaineE ="";

--- a/dtn/interface/joueurs/fiche.php
+++ b/dtn/interface/joueurs/fiche.php
@@ -269,6 +269,12 @@ if ($datemaj >$mkday -$huit){
                   &nbsp;<a href="#" onClick='AlertNumServeurHT();'
                 <?php }?>
                 alt="ht">HT-mail</a>
+	<?php 	if ($sesUser["idNiveauAcces"] == "4") { // Mise à jour sur Hattrick pour le sélectionneur
+    ?>          <form method="post" action="../maliste/miseajourunique.php">
+                <input type="hidden" name="joueur" value= <?=$joueurDTN["idHattrickJoueur"]?> />
+                <input type="submit" value="Mettre &agrave; jour sur Hattrick" />
+                </form>
+	<?php	}?>
               </td>
 
               <td  width="35%" nowrap align="right">

--- a/dtn/interface/joueurs/fiche.php
+++ b/dtn/interface/joueurs/fiche.php
@@ -22,7 +22,7 @@ if (isset($htid))
   $joueurDTN = getJoueurHt($htid);
   $id = $joueurDTN["idJoueur"];
   if (empty($joueurDTN)) {
-    echo("Joueur inexistant dans la base DTN !");
+    header("location: ../joueurs/verifPlayer.php");
     exit;
   }
 } else {

--- a/dtn/interface/joueurs/ficheDTN.php
+++ b/dtn/interface/joueurs/ficheDTN.php
@@ -301,8 +301,9 @@ if(isset($msg)) {?>
                   break;
 
                   case "coup franc":
-                  $nbSemaineE = "";
+                  $nbSemaineE = '(+'.$joueurDTN["nbSemaineCoupFranc"].')';
                   $nomColCarac = 'idPA';
+				  $nomColNbSem = 'nbSemaineCoupFranc';
                   break;
 
                   default:

--- a/dtn/interface/joueurs/ficheDTN.php
+++ b/dtn/interface/joueurs/ficheDTN.php
@@ -601,6 +601,7 @@ $reqHJ = $conn->query($sqlHJ);
 
           $i=1;
           foreach($conn->query($sqlClubsHisto) as $lHisto) {
+            $lHisto["createur"]='[Autre]';
             if ($lHisto["role_createur"]=="D") {$lHisto["createur"]='[DTN]';}
             else if ($lHisto["role_createur"]=="P") {$lHisto["createur"]='[Proprio]';}
             $lHisto["createur"].=$lHisto["cree_par"];?>

--- a/dtn/interface/joueurs/ficheForum.php
+++ b/dtn/interface/joueurs/ficheForum.php
@@ -108,7 +108,7 @@ switch($_SESSION['sesUser']["idNiveauAcces"]){
 }
 
 
-require("../menu/menuJoueur.php");
+require("../menu/menuJoueur_autres_onglets.php");
 
 
 ?>

--- a/dtn/interface/joueurs/ficheForum.php
+++ b/dtn/interface/joueurs/ficheForum.php
@@ -156,7 +156,7 @@ require("../menu/menuJoueur.php");
 
   Buteur : <?=$lstCaractJ[$infJ["idButeur"]]["intituleCaracFR"]?> (<?=$infJ["idButeur"]?>) + <?=$infJ["nbSemaineButeur"]?> <br/>
 
-  Coup Franc : <?=$lstCaractJ[$infJ["idPA"]]["intituleCaracFR"]?> (<?=$infJ["idPA"]?>) <br/>
+  Coup Franc : <?=$lstCaractJ[$infJ["idPA"]]["intituleCaracFR"]?> (<?=$infJ["idPA"]?>) + <?=$infJ["nbSemaineCoupFranc"]?><br/>
   <br/>
   [u]Entrainement et commentaires[/u]: 
   <br/>

--- a/dtn/interface/joueurs/fiche_visu.php
+++ b/dtn/interface/joueurs/fiche_visu.php
@@ -218,7 +218,7 @@ $idHT=$infJ['idHattrickJoueur'];
         }else{ 
        		?><?=$infJ["loginAdminSuiveur"]?><?php }?>&nbsp;</strong></font><?php 		
 		}else if($infJ["archiveJoueur"] == 1){
-			 ?><font color="#FF0000"><strong>Ce joueur est archive&nbsp;</strong></font><?php
+			 ?><font color="#FF0000"><strong>Ce joueur est archiv&eacute;&nbsp;</strong></font><?php
 		}else {
 		  ?><font color="#FF0000"><strong>Ce joueur n'est pas suivi !&nbsp;</strong></font><?php
 		 }
@@ -321,6 +321,10 @@ $idHT=$infJ['idHattrickJoueur'];
 		
 			case "passe":
 			$nbSemaineE = '(+'.$infJ["nbSemainePasses"].')';
+			break;
+			
+			case "coup franc":
+			$nbSemaineE = '(+'.$infJ["nbSemaineCoupFranc"].')';
 			break;
 	
 			default:

--- a/dtn/interface/joueurs/fichehattrickchoix.php
+++ b/dtn/interface/joueurs/fichehattrickchoix.php
@@ -582,7 +582,7 @@ $pos=$lstSect[$infJs[1]['ht_posteAssigne']-1]["descriptifPosition"];
 if ($pos=="") $pos="aucun";
 $dtnsuivi="aucun";
 if ($infJs[1]["dtnSuiviJoueur_fk"]!=0) $dtnsuivi=$infJs[1]["loginAdminSuiveur"];    
-if ($origine=="unique") require("../menu/menuJoueur.php");
+if ($origine=="unique") require("../menu/menuJoueur_autres_onglets.php");
 ?>
 <table width="99%" border="1" cellspacing="0" cellpadding="0">
     <tr>

--- a/dtn/interface/joueurs/fichehattrickchoix.php
+++ b/dtn/interface/joueurs/fichehattrickchoix.php
@@ -454,7 +454,7 @@ function scanid()
       b=b+'/CF';
       c=c+' / ';
       if ('<?=$infJs[$i]["entrainement_id"]?>'==3) c=c+'[i][b]';
-      c=c+'<?=$infJs[$i]["idPA"]?>';
+      c=c+'<?=$infJs[$i]["idPA"]?>+<?=$infJs[$i]["nbSemaineCoupFranc"]?>';
       if ('<?=$infJs[$i]["entrainement_id"]?>'==3) c=c+'[/b][/i]';
 	  active[6] = true;
     }
@@ -480,7 +480,7 @@ function scanid()
 		active[3]?<?=$infJs[$i]["idAilier"]?>:0, <?=$infJs[$i]["nbSemaineAilier"]?>,
 		active[4]?<?=$infJs[$i]["idPasse"]?>:0, <?=$infJs[$i]["nbSemainePasses"]?>,
 		active[5]?<?=$infJs[$i]["idButeur"]?>:0, <?=$infJs[$i]["nbSemaineButeur"]?>,
-		active[6]?<?=$infJs[$i]["idPA"]?>:0);
+		active[6]?<?=$infJs[$i]["idPA"]?>:0, <?=$infJs[$i]["nbSemaineCoupFranc"]?>);
     if ((document.forms.form2.parasup[9].checked)) {
       //choix=HTMS
 <?php

--- a/dtn/interface/joueurs/ficheresumechoix.php
+++ b/dtn/interface/joueurs/ficheresumechoix.php
@@ -510,7 +510,7 @@ function scanid()
 		active[3]?<?=$infJs[$i]["idAilier"]?>:0, <?=$infJs[$i]["nbSemaineAilier"]?>,
 		active[4]?<?=$infJs[$i]["idPasse"]?>:0, <?=$infJs[$i]["nbSemainePasses"]?>,
 		active[5]?<?=$infJs[$i]["idButeur"]?>:0, <?=$infJs[$i]["nbSemaineButeur"]?>,
-		active[6]?<?=$infJs[$i]["idPA"]?>:0), <?=$infJs[$i]["nbSemaineCoupFranc"]?>;
+		active[6]?<?=$infJs[$i]["idPA"]?>:0, <?=$infJs[$i]["nbSemaineCoupFranc"]?>);
     if ((document.forms.form2.parasup[9].checked)) {
       //choix=HTMS
 <?php

--- a/dtn/interface/joueurs/ficheresumechoix.php
+++ b/dtn/interface/joueurs/ficheresumechoix.php
@@ -484,7 +484,7 @@ function scanid()
       b=b+'/CF';
       c=c+' / ';
       if ('<?=$infJs[$i]["entrainement_id"]?>'==3) c=c+'[b][i]';
-      c=c+'<?=$infJs[$i]["idPA"]?>';
+      c=c+'<?=$infJs[$i]["idPA"]?>+<?=$infJs[$i]["nbSemaineCoupFranc"]?>';
       if ('<?=$infJs[$i]["entrainement_id"]?>'==3) c=c+'[/i][/b]';
 	  active[6] = true;
     }
@@ -510,7 +510,7 @@ function scanid()
 		active[3]?<?=$infJs[$i]["idAilier"]?>:0, <?=$infJs[$i]["nbSemaineAilier"]?>,
 		active[4]?<?=$infJs[$i]["idPasse"]?>:0, <?=$infJs[$i]["nbSemainePasses"]?>,
 		active[5]?<?=$infJs[$i]["idButeur"]?>:0, <?=$infJs[$i]["nbSemaineButeur"]?>,
-		active[6]?<?=$infJs[$i]["idPA"]?>:0);
+		active[6]?<?=$infJs[$i]["idPA"]?>:0), <?=$infJs[$i]["nbSemaineCoupFranc"]?>;
     if ((document.forms.form2.parasup[9].checked)) {
       //choix=HTMS
 <?php

--- a/dtn/interface/joueurs/ficheresumechoix.php
+++ b/dtn/interface/joueurs/ficheresumechoix.php
@@ -612,7 +612,7 @@ $pos=$lstSect[$infJs[1]['ht_posteAssigne']-1]["descriptifPosition"];
 if ($pos=="") $pos="aucun";
 $dtnsuivi="aucun";
 if ($infJs[1]["dtnSuiviJoueur_fk"]!=0) $dtnsuivi=$infJs[1]["loginAdminSuiveur"];    
-if ($origine=="unique") require("../menu/menuJoueur.php");
+if ($origine=="unique") require("../menu/menuJoueur_autres_onglets.php");
 ?>
 <table width="99%" border="1" cellspacing="0" cellpadding="0">
     <tr>

--- a/dtn/interface/joueurs/ficheslackchoix.php
+++ b/dtn/interface/joueurs/ficheslackchoix.php
@@ -580,7 +580,7 @@ $pos=$lstSect[$infJs[1]['ht_posteAssigne']-1]["descriptifPosition"];
 if ($pos=="") $pos="aucun";
 $dtnsuivi="aucun";
 if ($infJs[1]["dtnSuiviJoueur_fk"]!=0) $dtnsuivi=$infJs[1]["loginAdminSuiveur"];    
-if ($origine=="unique") require("../menu/menuJoueur.php");
+if ($origine=="unique") require("../menu/menuJoueur_autres_onglets.php");
 ?>
 <table width="99%" border="1" cellspacing="0" cellpadding="0">
     <tr>

--- a/dtn/interface/joueurs/ficheslackchoix.php
+++ b/dtn/interface/joueurs/ficheslackchoix.php
@@ -449,7 +449,7 @@ function scanid()
       b=b+'/CF';
       c=c+' / ';
       if ('<?=$infJs[$i]["entrainement_id"]?>'==3) c=c+'_*';
-      c=c+'<?=$infJs[$i]["idPA"]?>';
+      c=c+'<?=$infJs[$i]["idPA"]?>+<?=$infJs[$i]["nbSemaineCoupFranc"]?>';
       if ('<?=$infJs[$i]["entrainement_id"]?>'==3) c=c+'*_';
 	  active[6] = true;
     }
@@ -475,7 +475,7 @@ function scanid()
 		active[3]?<?=$infJs[$i]["idAilier"]?>:0, <?=$infJs[$i]["nbSemaineAilier"]?>,
 		active[4]?<?=$infJs[$i]["idPasse"]?>:0, <?=$infJs[$i]["nbSemainePasses"]?>,
 		active[5]?<?=$infJs[$i]["idButeur"]?>:0, <?=$infJs[$i]["nbSemaineButeur"]?>,
-		active[6]?<?=$infJs[$i]["idPA"]?>:0);
+		active[6]?<?=$infJs[$i]["idPA"]?>:0, <?=$infJs[$i]["nbSemaineCoupFranc"]?>);
     if ((document.forms.form2.parasup[9].checked)) {
       //choix=HTMS
 <?php

--- a/dtn/interface/joueurs/histoJoueur.php
+++ b/dtn/interface/joueurs/histoJoueur.php
@@ -118,7 +118,7 @@ $id=$idJoueur;
 $idHT=$infJ['idHattrickJoueur'];
 $idClubHT=$infJ['teamid'];
 
-require("../menu/menuJoueur.php");
+require("../menu/menuJoueur_autres_onglets.php");
 
 
 ?>

--- a/dtn/interface/joueurs/liste.php
+++ b/dtn/interface/joueurs/liste.php
@@ -353,7 +353,7 @@ break;
                     <?php if ($transferListed==1) {?><img height="12" src="../images/enVente.JPG" title="Plac&eacute; sur la liste des transferts"><?php }?>
                     <a href ="<?=$url?>/joueurs/ficheDTN.php?id=<?=$l["idJoueur"]?>" class="bred1"> 
                       <b> 
-                      <?=strtolower($l["prenomJoueur"])?> <?=strtolower($l["nomJoueur"])?>
+                      <?=$l["prenomJoueur"]?> <?=$l["nomJoueur"]?>
 					  <?php if (isset($l["surnomJoueur"])) echo " (".$l["surnomJoueur"].")"; ?>
                       </b> 
                       </a> 

--- a/dtn/interface/joueurs/listeExportCsv.php
+++ b/dtn/interface/joueurs/listeExportCsv.php
@@ -300,6 +300,7 @@ $semaine["buteur"] = $infTraining["nbSemaineButeur"];
 $semaine["gardien"] = $infTraining["nbSemaineGardien"];
 $semaine["passe"] = $infTraining["nbSemainePasse"];
 $semaine["defense"] = $infTraining["nbSemaineDefense"];
+$semaine["coupfranc"] = $infTraining["nbSemaineCoupFranc"];
 
 			  $coeff = getCoeffSelectionneur(1);
 				if($useFormule == 1 && $coeff["useit"] == 1){
@@ -328,6 +329,7 @@ $semaine["buteur"] = $infTraining["nbSemaineButeur"];
 $semaine["gardien"] = $infTraining["nbSemaineGardien"];
 $semaine["passe"] = $infTraining["nbSemainePasse"];
 $semaine["defense"] = $infTraining["nbSemaineDefense"];
+$semaine["coupfranc"] = $infTraining["nbSemaineCoupFranc"];
 
 			  $coeff = getCoeffSelectionneur(2);
 				if($useFormule == 1 && $coeff["useit"] == 1){
@@ -356,6 +358,7 @@ $semaine["buteur"] = $infTraining["nbSemaineButeur"];
 $semaine["gardien"] = $infTraining["nbSemaineGardien"];
 $semaine["passe"] = $infTraining["nbSemainePasse"];
 $semaine["defense"] = $infTraining["nbSemaineDefense"];
+$semaine["coupfranc"] = $infTraining["nbSemaineCoupFranc"];
 
 			  $coeff = getCoeffSelectionneur(3);
 				if($useFormule == 1 && $coeff["useit"] == 1){
@@ -384,6 +387,7 @@ $semaine["buteur"] = $infTraining["nbSemaineButeur"];
 $semaine["gardien"] = $infTraining["nbSemaineGardien"];
 $semaine["passe"] = $infTraining["nbSemainePasse"];
 $semaine["defense"] = $infTraining["nbSemaineDefense"];
+$semaine["coupfranc"] = $infTraining["nbSemaineCoupFranc"];
 
 			  $coeff = getCoeffSelectionneur(4);
 				if($useFormule == 1 && $coeff["useit"] == 1){
@@ -412,6 +416,7 @@ $semaine["buteur"] = $infTraining["nbSemaineButeur"];
 $semaine["gardien"] = $infTraining["nbSemaineGardien"];
 $semaine["passe"] = $infTraining["nbSemainePasse"];
 $semaine["defense"] = $infTraining["nbSemaineDefense"];
+$semaine["coupfranc"] = $infTraining["nbSemaineCoupFranc"];
 
 			  $coeff = getCoeffSelectionneur(5);
 				if($useFormule == 1 && $coeff["useit"] == 1){

--- a/dtn/interface/joueurs/listeInternational.php
+++ b/dtn/interface/joueurs/listeInternational.php
@@ -603,6 +603,7 @@ $semaine["buteur"] = $infTraining["nbSemaineButeur"];
 $semaine["gardien"] = $infTraining["nbSemaineGardien"];
 $semaine["passe"] = $infTraining["nbSemainePasses"];
 $semaine["defense"] = $infTraining["nbSemaineDefense"];
+$semaine["coupfranc"] = $infTraining["nbSemaineCoupFranc"];
 
 
 	switch($affPosition){

--- a/dtn/interface/joueurs/patchNote.php
+++ b/dtn/interface/joueurs/patchNote.php
@@ -52,6 +52,7 @@ foreach($conn->query($sql) as $lst){
 	$semaine["defense"] = $infJoueur["nbSemaineDefense"];
 	$semaine["buteur"] = $infJoueur["nbSemaineButeur"];
 	$semaine["ailier"] = $infJoueur["nbSemaineAilier"] ;
+	$semaine["coupfranc"] = $infTraining["nbSemaineCoupFranc"];
 
 	$valeur  = $infJoueur["valeurEnCours"];
 	$fin = $infJoueur["finFormation"];

--- a/dtn/interface/joueurs/purgeJoueurs.php
+++ b/dtn/interface/joueurs/purgeJoueurs.php
@@ -139,6 +139,7 @@ $sqlreel = "SELECT
               ht_entrainement.nbSemaineDefense,
               ht_entrainement.nbSemaineAilier,
               ht_entrainement.nbSemaineButeur,
+              ht_entrainement.nbSemaineCoupFranc,
               ht_joueurs.idJoueur,
               ht_joueurs.idHattrickJoueur,
               ht_joueurs.prenomJoueur,
@@ -407,7 +408,7 @@ if(count($lstJ)==0) {
 					</TR>
 					<TR>
 						<TD><B>Buteur :&nbsp; </B></TD><TD bgcolor="<?=$buteurColor?>"><?=$lstCarac[$lstJ[$j]["idButeur"]]["intituleCaracFR"]?><?php afficheLesPlus($lstJ[$j],"nbSemaineButeur"); ?></TD>
-						<TD><B>&nbsp; &nbsp; Coup franc :&nbsp; </B></TD><TD><?=$lstCarac[$lstJ[$j]["idPA"]]["intituleCaracFR"]?></TD>
+						<TD><B>&nbsp; &nbsp; Coup franc :&nbsp; </B></TD><TD><?=$lstCarac[$lstJ[$j]["idPA"]]["intituleCaracFR"]?><?php afficheLesPlus($lstJ[$j],"nbSemaineCoupFranc"); ?><</TD>
 					</TR>
 					<TR>
 						<TD colspan=4><B>Motif Purge :&nbsp;

--- a/dtn/interface/maliste/maliste.php
+++ b/dtn/interface/maliste/maliste.php
@@ -154,7 +154,7 @@ document.body.scrollTop = scrollPos;
       <td valign="middle">Export Excel :&nbsp;</td>
       <td valign="middle"><a href="../outils/ExportCsv.php?ordre=<?=$ordre?>&sens=<?=$sens?>&lang=<?=$lang?>&masque=<?=$masque?>&affPosition=<?=$affPosition?>&typeExport=<?=$typeExport?>"><img border=1 src="../images/icone-excel.jpg" title="Exporter Ma Liste sur Excel"></a></td>
     
-      <!-- Rajout export vers fiches résumé -->
+      <!-- Rajout export vers fiches rÃ©sumÃ© -->
       <!-- Fireproofed le 05/11/2010 -->
       
       <td valign="middle">
@@ -186,7 +186,9 @@ document.body.scrollTop = scrollPos;
                     <td width="70" ><font color="#FFFFFF">&nbsp;Potentiel HTMS</font></td>
 <!--                <td width="70" style="cursor:default;" onClick="chgTri('TODO (valeur htms)','<?=$sens?>','<?=$masque?>','<?=$affPosition?>')"><font color="#FFFFFF">&nbsp;Valeur HTMS <i class="fa fa-sort-amount-asc"></i></font></td>
                     <td width="70" style="cursor:default;" onClick="chgTri('TODO (potentiel htms)','<?=$sens?>','<?=$masque?>','<?=$affPosition?>')"><font color="#FFFFFF">&nbsp;Potentiel HTMS <i class="fa fa-sort-amount-asc"></i></font></td> -->
-                    <td width="60" style="cursor:default;" onClick="chgTri('datenaiss','<?=$sens?>','<?=$masque?>','<?=$affPosition?>')"> 
+                    <td width="60" ><div align="center"><font color="#FFFFFF">&nbsp;TSI</font></div></td>
+<!--                <td width="60" style="cursor:default;" onClick="chgTri('TODO (TSI)','<?=$sens?>','<?=$masque?>','<?=$affPosition?>')"><font color="#FFFFFF">&nbsp;Potentiel HTMS <i class="fa fa-sort-amount-asc"></i></font></td> -->
+					<td width="60" style="cursor:default;" onClick="chgTri('datenaiss','<?=$sens?>','<?=$masque?>','<?=$affPosition?>')"> 
                       <div align="center"><font color="#FFFFFF">Age<i class="fa fa-sort-amount-asc"></i></font></div></td>
                     
                     <td width="100"> 
@@ -346,8 +348,8 @@ foreach ($conn->query($sql) as $l) {
 	$ligne3 = $req3->fetch(PDO::FETCH_ASSOC);
 	extract($ligne3);
 
-// Extraction statut du joueur à la dernière MàJ (en vente ou non)
-            $sql4= "SELECT transferListed FROM $tbl_joueurs_histo
+// Extraction statut du joueur Ã  la derniÃ¨re MÃ J (en vente ou non)
+            $sql4= "SELECT transferListed, tsi FROM $tbl_joueurs_histo
                    WHERE id_joueur_fk=".$l["idHattrickJoueur"]." 
                    ORDER BY date_histo DESC LIMIT 1";
             $req4 = $conn->query($sql4);
@@ -403,7 +405,7 @@ foreach ($conn->query($sql) as $l) {
     $ageetjours = ageetjour($infJ["datenaiss"]);
 	$tabage = explode(" - ",$ageetjours);
 	$htms = htmspoint($tabage[0], $tabage[1], $infJ["idGardien"], $infJ["idDefense"], $infJ["idConstruction"], $infJ["idAilier"], $infJ["idPasse"], $infJ["idButeur"], $infJ["idPA"]);
-
+	
 	global $class;
 ?>
                   <tr bgcolor="#FFFFFF" align="right"> 
@@ -427,6 +429,7 @@ foreach ($conn->query($sql) as $l) {
                     <td width="55" nowrap align="center"><?=$date[2]?>/<?=$date[1]?>/<?=$date[0]?></td>
                     <td width="55" nowrap align="center"><?=$htms["value"]?></td>
                     <td width="55" nowrap align="center"><?=$htms["potential"]?></td>
+					<td width="55" nowrap align="center"><?=number_format($tsi, "0"," ", " ")?></td>
                     <td nowrap><div align="center"><?=$l["AgeAn"]."-".$l["AgeJour"]?></div></td>
                     <td width="20"> <div align="center"><?=$libelle_type_entrainement?></div></td>
                     <td width="20"> <div align="center"><?=$intensite?></div></td>
@@ -546,7 +549,7 @@ foreach ($conn->query($sql) as $l) {
 
 }
 
-$listID=substr($listID,0,-1); // enlève le dernier ;
+$listID=substr($listID,0,-1); // enlÃ¨ve le dernier ;
 $_SESSION['ListeFicheResume']=$listID;
 
 ?>

--- a/dtn/interface/maliste/maliste.php
+++ b/dtn/interface/maliste/maliste.php
@@ -418,7 +418,7 @@ foreach ($conn->query($sql) as $l) {
                     <?php if ($transferListed==1) {?><img height="12" src="../images/enVente.JPG" title="Plac&eacute; sur la liste des transferts"><?php }?>
                     <a href ="<?=$url?>/joueurs/ficheDTN.php?id=<?=$l["idJoueur"]?>" class=<?=$class?>> 
                       <b> 
-                      <?=strtolower($l["prenomJoueur"])?> <?=strtolower($l["nomJoueur"])?>
+                      <?=$l["prenomJoueur"]?> <?=$l["nomJoueur"]?>
 					  <?php if (isset($l["surnomJoueur"])) echo " (".$l["surnomJoueur"].")"; ?>
                       </b> 
                       </a> 

--- a/dtn/interface/maliste/maliste.php
+++ b/dtn/interface/maliste/maliste.php
@@ -445,7 +445,7 @@ foreach ($conn->query($sql) as $l) {
                     <td width="30" <?php if ($ailier==1) echo "bgcolor = $ailierColor";?>><div align="center"><?=$l["idAilier"]?> <?php afficheLesPlus($infJ,"nbSemaineAilier"); ?></div></td>
                     <td width="30" <?php if ($passe==1) echo "bgcolor = $passeColor";?>><div align="center"><?=$l["idPasse"]?> <?php afficheLesPlus($infJ,"nbSemainePasses"); ?></div></td>
                     <td width="30" <?php if ($buteur==1) echo "bgcolor = $buteurColor";?>><div align="center"><?=$l["idButeur"]?> <?php afficheLesPlus($infJ,"nbSemaineButeur"); ?></div></td>
-                    <td width="30" > <div align="center"><?=$l["idPA"]?></div></td>
+                    <td width="30" > <div align="center"><?=$l["idPA"]?><?php afficheLesPlus($infJ,"nbSemaineCoupFranc"); ?></div></td>
                   <td width="3" bgcolor="#FFFFDD"> 
                       &nbsp;</td>
 

--- a/dtn/interface/menu/menuAdmin.php
+++ b/dtn/interface/menu/menuAdmin.php
@@ -1,8 +1,8 @@
 <?php 
-// Variable paramétrage de la page
-$_SESSION['acces']="INTERFACE"; // sert à avoir un affichage personnalisé pour les composants utilisés dans le portail et l'interface
+// Variable paramÃ©trage de la page
+$_SESSION['acces']="INTERFACE"; // sert Ã  avoir un affichage personnalisÃ© pour les composants utilisÃ©s dans le portail et l'interface
 $nomFicPhpCourant = explode("?",$_SERVER['REQUEST_URI']);
-$callbackUrl="https://".$_SERVER['HTTP_HOST'].$nomFicPhpCourant[0]."?mode=retour"; // Url de retour après authentification sur HT
+$callbackUrl="https://".$_SERVER['HTTP_HOST'].$nomFicPhpCourant[0]."?mode=retour"; // Url de retour aprÃ¨s authentification sur HT
 include($_SERVER['DOCUMENT_ROOT'].'/gestion_session_HT.php');
 include_once($_SERVER['DOCUMENT_ROOT'].'/language/fr.php');
 
@@ -32,7 +32,12 @@ if(!isset($_SESSION['sesUser']["idAdmin"]))
 	<td width="1%" class="bred" nowrap nospan><a href="<?=$url?>/index2.php"><?=$sesUser["IntituleNiveauAcces"]?></a>&nbsp;&gt;<span class="breadvar"> <?=$sesUser["loginAdmin"]?></span></td>
 
 	<td colspan=2 align="right" valign="bottom" nowrap width="1%">
-	<a class="smliensorange" href="<?=$url?>/equipe/superviseur.php">Gestion</a>&nbsp;|&nbsp;
+		<form method="get" action="<?=$url?>/formJoueurDirect.php" style="display: inline;">
+		<label for "idJoueurHT">Acc&egrave;s Direct : </label>
+		<input type="text" name="idJoueurHT" value="ID Joueur" size="8" onfocus="if(this.value=='ID Joueur'){this.value=''}" onblur="if(this.value==''){this.value = 'ID Joueur'}"/>
+        <input type="submit" value="Voir" />
+        </form>
+	&nbsp;| <a class="smliensorange" href="<?=$url?>/equipe/superviseur.php">Gestion</a>&nbsp;|&nbsp;
 	<a class="smliensorange" href="<?=$url?>/national_team/team.php?selection=A">Equipes Nationales</a>&nbsp;|&nbsp;
 	<a class="smliensorange" href="<?=$url?>/joueurs/toplist.php" alt="Chercher">Base de donn&eacute;es</a>&nbsp;|&nbsp;
 	<a class="smliensorange" href="<?=$url?>/consulter/messagesMaListe.php" alt="Messages Proprios">Messages Proprios</a>&nbsp;|&nbsp;
@@ -48,7 +53,7 @@ if(!isset($_SESSION['sesUser']["idAdmin"]))
 
 <tr align="left">
 	<td valign="top" width="99%"><span class="small">Saison <?=$_SESSION['sesUser']['saison']?>, semaine <?=$numeroSemaine?></span></td>
-	<td align="left" valign="top" ><A class="smliensorange" href="<?=$url?>/index.php?action=logout" class="btn">Quitter Interface</a></td>
+	<td align="right" valign="top" ><A class="smliensorange" href="<?=$url?>/index.php?action=logout" class="btn">Quitter Interface</a></td>
 	<td align="right" valign="top" ><img src="<?=$url?>/images/logo_dtn.jpg" align="right" valign="top"></td>
 </tr>
 </table>

--- a/dtn/interface/menu/menuCoach.php
+++ b/dtn/interface/menu/menuCoach.php
@@ -1,10 +1,10 @@
 <?php 
-// Variable paramétrage de la page
+// Variable paramÃ©trage de la page
 $nomFicPhpCourant = explode("?",$_SERVER['REQUEST_URI']);
-$callbackUrl="https://".$_SERVER['HTTP_HOST'].$nomFicPhpCourant[0]."?mode=retour"; // Url de retour après authentification sur HT
+$callbackUrl="https://".$_SERVER['HTTP_HOST'].$nomFicPhpCourant[0]."?mode=retour"; // Url de retour aprÃ¨s authentification sur HT
 include($_SERVER['DOCUMENT_ROOT'].'/gestion_session_HT.php');
 include_once($_SERVER['DOCUMENT_ROOT'].'/language/fr.php');
-$_SESSION['acces']="INTERFACE"; // sert à avoir un affichage personnalisé pour les composants utilisés dans le portail et l'interface
+$_SESSION['acces']="INTERFACE"; // sert Ã  avoir un affichage personnalisÃ© pour les composants utilisÃ©s dans le portail et l'interface
 
 if(!isset($_SESSION['sesUser']["idAdmin"]))
 {
@@ -30,7 +30,12 @@ if(!isset($_SESSION['sesUser']["idAdmin"]))
 	<td width="1%" class="bred" nowrap nospan><a href="<?=$url?>/index2.php"><?=$sesUser["IntituleNiveauAcces"]?></a>&nbsp;&gt;<span class="breadvar"> <?=$_SESSION['sesUser']["loginAdmin"]?></span></td>
 
 	<td colspan=2 align="right" valign="bottom" nowrap width="1%">
-	<A class="smliensorange" href="<?=$url?>/settings.php?affinfoPerso=1">Mon Profil</a>&nbsp;|
+		<form method="get" action="<?=$url?>/formJoueurDirect.php" style="display: inline;">
+		<label for "idJoueurHT">Acc&egrave;s Direct : </label>
+		<input type="text" name="idJoueurHT" value="ID Joueur" size="8" onfocus="if(this.value=='ID Joueur'){this.value=''}" onblur="if(this.value==''){this.value = 'ID Joueur'}"/>
+        <input type="submit" value="Voir" />
+        </form>
+	&nbsp;|	<A class="smliensorange" href="<?=$url?>/settings.php?affinfoPerso=1">Mon Profil</a>&nbsp;|
 	&nbsp;<A class="smliensorange" href="<?=$url?>/joueurs/listeInternational.php">Joueurs</a>&nbsp;|
 	&nbsp;<A class="smliensorange" href="<?=$url?>/joueurs/toplist.php">Base de donn&eacute;es</a>&nbsp;|
 	&nbsp;<A class="smliensorange" href="<?=$url?>/joueurs/selection.php" alt="ma liste">S&eacute;lection</a>&nbsp;|
@@ -45,7 +50,7 @@ if(!isset($_SESSION['sesUser']["idAdmin"]))
 
 <tr align="left">
 	<td valign="top" width="99%"><span class="small">Saison <?=$_SESSION['sesUser']["saison"]?>, semaine <?=$numeroSemaine?></span></td>
-	<td align="left" valign="top" ><A class="smliensorange" href="<?=$url?>/index.php?action=logout" class="btn">Quitter Interface</a></td>
+	<td align="right" valign="top" ><A class="smliensorange" href="<?=$url?>/index.php?action=logout" class="btn">Quitter Interface</a></td>
 	<td align="right" valign="top" ><img src="<?=$url?>/images/logo_dtn.jpg" align="right" valign="top"></td>
 </tr>
 </table>

--- a/dtn/interface/menu/menuDTN.php
+++ b/dtn/interface/menu/menuDTN.php
@@ -1,10 +1,10 @@
 <?php 
-// Variable paramétrage de la page
+// Variable paramÃ©trage de la page
 $nomFicPhpCourant = explode("?",$_SERVER['REQUEST_URI']);
-$callbackUrl="https://".$_SERVER['HTTP_HOST'].$nomFicPhpCourant[0]."?mode=retour"; // Url de retour après authentification sur HT
+$callbackUrl="https://".$_SERVER['HTTP_HOST'].$nomFicPhpCourant[0]."?mode=retour"; // Url de retour aprÃ¨s authentification sur HT
 include($_SERVER['DOCUMENT_ROOT'].'/gestion_session_HT.php');
 include_once($_SERVER['DOCUMENT_ROOT'].'/language/fr.php');
-$_SESSION['acces']="INTERFACE"; // sert à avoir un affichage personnalisé pour les composants utilisés dans le portail et l'interface
+$_SESSION['acces']="INTERFACE"; // sert Ã  avoir un affichage personnalisÃ© pour les composants utilisÃ©s dans le portail et l'interface
 
 if(!isset($_SESSION['sesUser']["idAdmin"]))
 {
@@ -31,7 +31,12 @@ if(!isset($_SESSION['sesUser']["idAdmin"]))
 	<td width="1%" class="bred" nowrap nospan><a href="<?=$url?>/index2.php"><?=$_SESSION['sesUser']["IntituleNiveauAcces"]?></a>&nbsp;&gt;<span class="breadvar"> <?=$_SESSION['sesUser']["loginAdmin"]?></span></td>
 
 	<td colspan=2 align="right" valign="bottom" nowrap width="1%">
-	<A class="smliensorange" href="<?=$url?>/settings.php?affinfoPerso=1" class="btn" alt="configuration">Mon Profil</a>&nbsp;|&nbsp;
+		<form method="get" action="<?=$url?>/formJoueurDirect.php" style="display: inline;">
+		<label for "idJoueurHT">Acc&egrave;s Direct : </label>
+		<input type="text" name="idJoueurHT" value="ID Joueur" size="8" onfocus="if(this.value=='ID Joueur'){this.value=''}" onblur="if(this.value==''){this.value = 'ID Joueur'}"/>
+        <input type="submit" value="Voir" />
+        </form>
+	&nbsp;| <A class="smliensorange" href="<?=$url?>/settings.php?affinfoPerso=1" class="btn" alt="configuration">Mon Profil</a>&nbsp;|&nbsp;
 	<A class="smliensorange" href="<?=$url?>/national_team/team.php?selection=A" class="btn">Equipes Nationales</a>&nbsp;|&nbsp;
 	<A class="smliensorange" href="<?=$url?>/joueurs/toplist.php" class="btn" alt="Chercher">Base de donn&eacute;es</a>&nbsp;|&nbsp;
 	<a class="smliensorange" href="<?=$url?>/consulter/messagesMaListe.php" alt="Messages Proprios">Messages Proprios</a>&nbsp;|&nbsp;
@@ -48,7 +53,7 @@ if(!isset($_SESSION['sesUser']["idAdmin"]))
 
 <tr align="left">
 	<td valign="top" width="99%"><span class="small">Saison <?=$_SESSION['sesUser']["saison"]?>, semaine <?=$numeroSemaine?></span></td>
-	<td align="left" valign="top" ><A class="smliensorange" href="<?=$url?>/index.php?action=logout" class="btn">Quitter Interface</a></td>
+	<td align="right" valign="top" ><A class="smliensorange" href="<?=$url?>/index.php?action=logout" class="btn">Quitter Interface</a></td>
 	<td align="right" valign="top" ><img src="<?=$url?>/images/logo_dtn.jpg" align="right" valign="top"></td>
 </tr>
 </table>

--- a/dtn/interface/menu/menuJoueur.php
+++ b/dtn/interface/menu/menuJoueur.php
@@ -2,8 +2,6 @@
 if(isset($idHT)) {
 
 global $infJ;
-  $joueurDTN = getJoueurHt($htid);
-
 
 /***********************************************
 * Type de menus :

--- a/dtn/interface/menu/menuJoueur.php
+++ b/dtn/interface/menu/menuJoueur.php
@@ -2,6 +2,8 @@
 if(isset($idHT)) {
 
 global $infJ;
+  $joueurDTN = getJoueurHt($htid);
+
 
 /***********************************************
 * Type de menus :

--- a/dtn/interface/menu/menuJoueur.php
+++ b/dtn/interface/menu/menuJoueur.php
@@ -1,7 +1,7 @@
 <?php
 if(isset($idHT)) {
-	
-	global $infJ;
+
+global $infJ;
 
 /***********************************************
 * Type de menus :
@@ -17,7 +17,7 @@ if(isset($idHT)) {
 ***********************************************/
 if (($sesUser["idNiveauAcces"]=="1") or ($sesUser["idNiveauAcces"]=="4")) {$TypeMenu=1;}
 else {
-      if (($sesUser["idPosition_fk"] == $infJ["ht_posteAssigne"]) or ($infJ["ht_posteAssigne"]==0) or ($sesUser["idPosition_fk"]==0 and $sesUser["idNiveauAcces"]=="2") ) {$TypeMenu=2;}
+      if (($sesUser["idPosition_fk"] == $joueurDTN["ht_posteAssigne"]) or ($joueurDTN["ht_posteAssigne"]==0) or ($sesUser["idPosition_fk"]==0 and $sesUser["idNiveauAcces"]=="2") ) {$TypeMenu=2;}
       else {$TypeMenu=3;}
 }
 //Un DTN ne doit pas pouvoir modifier la fiche de son propre joueur par Musta56 le 28/07/2009 => http://www.ht-fff.org/bug/view.php?id=98

--- a/dtn/interface/menu/menuJoueur_autres_onglets.php
+++ b/dtn/interface/menu/menuJoueur_autres_onglets.php
@@ -1,0 +1,57 @@
+<?php
+if(isset($idHT)) {
+
+global $infJ;
+
+/***********************************************
+* Type de menus :
+* 1- Menu Complet (Fiche consultation |  Fiche DTN |  Graphiques |  Histo modifs |  Club |  Fiche Forum |  Fiche Résumé  |  Etoiles |  Commentaires / Notes   |  Chercher un joueur )
+* 2- Menu Complet sans "chercher un joueur" ( Fiche consultation |  Fiche DTN |  Graphiques |  Histo modifs |  Club |  Fiche Forum |  Fiche Résumé  |  Etoiles |  Commentaires / Notes)
+* 3- Menu de consultation  ( Fiche consultation |  Fiche Forum |  Fiche Résumé )
+* Menu 1 pour les sélectionneur et les admins        
+* Menu 2 - Si le joueur appartient au secteur du dtn ou dtn+
+*        - Si le joueur n'appartient à aucun secteur
+*        - Si le dtn + a accès à tous les secteurs
+* Menu 3 - Si joueur n'appartient pas au secteur du dtn ou dtn+
+*        - Si le dtn a accès à tous les secteurs             
+***********************************************/
+if (($sesUser["idNiveauAcces"]=="1") or ($sesUser["idNiveauAcces"]=="4")) {$TypeMenu=1;}
+else {
+      if (($sesUser["idPosition_fk"] == $infJ["ht_posteAssigne"]) or ($infJ["ht_posteAssigne"]==0) or ($sesUser["idPosition_fk"]==0 and $sesUser["idNiveauAcces"]=="2") ) {$TypeMenu=2;}
+      else {$TypeMenu=3;}
+}
+//Un DTN ne doit pas pouvoir modifier la fiche de son propre joueur par Musta56 le 28/07/2009 => http://www.ht-fff.org/bug/view.php?id=98
+if ($sesUser["idAdminHT"] == $idClubHT) {$TypeMenu=3;}
+
+
+
+?>
+<table border=0 width=100%>
+<tr><td align="left" nospan>&nbsp;<a href="<?=$url?>/joueurs/fiche.php?htid=<?=$idHT?>" class="smliensorange" alt="consulter">Fiche consultation</a>&nbsp;|
+<?php // On affiche le menu fiche dtn que si le joueur appartient au secteur du dtn ou si c'est le sélectionneur qui est connecté
+if ($TypeMenu <= 2) { ?>
+	&nbsp;<A class="smliensorange" href="<?=$url?>/joueurs/ficheDTN.php?htid=<?=$idHT?>" alt="modifier">Fiche DTN</a>&nbsp;|
+	&nbsp;<A class="smliensorange" href="<?=$url?>/joueurs/graphProgression.php?id=<?=$id?>" alt="graphiques">Graphiques</a>&nbsp;|
+<?php } ?>
+	&nbsp;<A class="smliensorange" href="<?=$url?>/joueurs/histoJoueur.php?htid=<?=$idHT?>" alt="Histos">Histo modifs</a>&nbsp;|
+<?php if ($TypeMenu <= 2) { ?>
+	&nbsp;<A class="smliensorange" href="<?=$url?>/clubs/fiche_club.php?idClubHT=<?=$idClubHT?>" alt="Club">Club</a>&nbsp;|
+<?php } ?>
+	&nbsp;<A class="smliensorange" href="<?=$url?>/joueurs/ficheForum.php?htid=<?=$idHT?>" alt="forum">Fiche Forum</a>&nbsp;|
+	&nbsp;<a class="smliensorange" href="<?=$url?>/joueurs/ficheresumechoix.php?htid=<?=$idHT?>&origine=<?php echo "unique"?>" alt="resume">Fiche R&eacute;sum&eacute;</a>&nbsp;|
+	&nbsp;<a class="smliensorange" href="<?=$url?>/joueurs/ficheslackchoix.php?htid=<?=$idHT?>&origine=<?php echo "unique"?>" alt="resume">Fiche Slack</a>&nbsp;|
+	&nbsp;<a class="smliensorange" href="<?=$url?>/joueurs/fichehattrickchoix.php?htid=<?=$idHT?>&origine=<?php echo "unique"?>" alt="resume">Fiche Hattrick</a>&nbsp;
+    <?php if ($TypeMenu <= 2) { ?>
+  | &nbsp;<A class="smliensorange" href="<?=$url?>/joueurs/rapportDetaille.php?htid=<?=$idHT?>" alt="etoiles">Matchs</a>&nbsp;|
+    &nbsp;<A class="smliensorange" href="<?=$url?>/joueurs/commentaires.php?htid=<?=$idHT?>" alt="commentaires">Commentaires / Notes</a>
+<?php }
+
+if ($TypeMenu <= 1) {  ?>
+
+&nbsp;|
+	&nbsp;<A class="smliensorange" href="<?=$url?>/joueurs/verifPlayer.php" >Chercher un joueur</a>&nbsp;<?php } ?><!-- &nbsp;|
+	&nbsp;<A class="smliensorange" href="<?=$url?>/joueurs/rapportDetailleModif.php?fonction=insert&id=<?=$id?>" class="btn" alt="ajout match">Ajout Match</a>&nbsp;-->
+</td></tr></table>
+<?php
+}
+?>

--- a/dtn/interface/menu/menuSuperviseur.php
+++ b/dtn/interface/menu/menuSuperviseur.php
@@ -1,10 +1,10 @@
 <?php 
-// Variable paramétrage de la page
+// Variable paramÃ©trage de la page
 $nomFicPhpCourant = explode("?",$_SERVER['REQUEST_URI']);
-$callbackUrl="https://".$_SERVER['HTTP_HOST'].$nomFicPhpCourant[0]."?mode=retour"; // Url de retour après authentification sur HT
+$callbackUrl="https://".$_SERVER['HTTP_HOST'].$nomFicPhpCourant[0]."?mode=retour"; // Url de retour aprÃ¨s authentification sur HT
 include($_SERVER['DOCUMENT_ROOT'].'/gestion_session_HT.php');
 include_once($_SERVER['DOCUMENT_ROOT'].'/language/fr.php');
-$_SESSION['acces']="INTERFACE"; // sert à avoir un affichage personnalisé pour les composants utilisés dans le portail et l'interface
+$_SESSION['acces']="INTERFACE"; // sert Ã  avoir un affichage personnalisÃ© pour les composants utilisÃ©s dans le portail et l'interface
 
 if(!isset($_SESSION['sesUser']["idAdmin"]))
 {
@@ -33,7 +33,12 @@ if(!isset($_SESSION['sesUser']["idAdmin"]))
 	<td width="1%" class="bred" nowrap nospan><a href="<?=$url?>/index2.php"><?=$sesUser["IntituleNiveauAcces"]?></a>&nbsp;&gt;<span class="breadvar"> <?=$sesUser["loginAdmin"]?></span></td>
 
 	<td colspan=2 align="right" valign="bottom" nowrap width="1%">
-      <a class="smliensorange" href="<?=$url?>/equipe/mesdtns.php">Gestion</a>&nbsp;|&nbsp;
+		<form method="get" action="<?=$url?>/formJoueurDirect.php" style="display: inline;">
+		<label for "idJoueurHT">Acc&egrave;s Direct : </label>
+		<input type="text" name="idJoueurHT" value="ID Joueur" size="8" onfocus="if(this.value=='ID Joueur'){this.value=''}" onblur="if(this.value==''){this.value = 'ID Joueur'}"/>
+        <input type="submit" value="Voir" />
+        </form>
+	&nbsp;| <a class="smliensorange" href="<?=$url?>/equipe/mesdtns.php">Gestion</a>&nbsp;|&nbsp;
       <a class="smliensorange" href="<?=$url?>/national_team/team.php?selection=A">Equipes Nationales</a>&nbsp;|&nbsp;
       <a href="<?=$url?>/joueurs/toplist.php" class="smliensorange" alt="Chercher">Base de donn&eacute;es</a>&nbsp;|&nbsp;
 	<?php if ($sesUser["idPosition_fk"]!=0) { ?>
@@ -52,7 +57,7 @@ if(!isset($_SESSION['sesUser']["idAdmin"]))
 
 <tr align="left">
 	<td valign="top" width="99%"><span class="small">Saison <?=$_SESSION['sesUser']["saison"]?>, semaine <?=$numeroSemaine?></span></td>
-	<td align="left" valign="top" ><A class="smliensorange" href="<?=$url?>/index.php?action=logout" class="btn">Quitter Interface</a></td>
+	<td align="right" valign="top" ><A class="smliensorange" href="<?=$url?>/index.php?action=logout" class="btn">Quitter Interface</a></td>
 	<td align="right" valign="top" ><img src="<?=$url?>/images/logo_dtn.jpg" align="right" valign="top"></td>
 </tr>
 </table>

--- a/dtn/interface/outils/ExportCsv.php
+++ b/dtn/interface/outils/ExportCsv.php
@@ -106,22 +106,22 @@ switch ($sesUser["idPosition_fk"]) {
 ?> gardien;<?php
 		break;
 	case "2" : // cD
-?> cD;cD off;wB;wB off<?php
+?> cD;cD off;wB;wB off;<?php
 		break;
 	case "3" : // Wg
-?> Wg;Wg towards;Wg off<?php
+?> Wg;Wg towards;Wg off;<?php
 		break;
 	case "4" : //IM 
-?> iM def;iM;iM off<?php
+?> iM def;iM;iM off;<?php
 		break;
 	case "5" : // Fw
-?> Fw def;Fw<?php
+?> Fw def;Fw;<?php
 		break;
 	default :
-?> gK;cD;iM;Wg off;Fw<?php
+?> gK;cD;iM;Wg off;Fw;<?php
 		break;
 }
-?>HTMS<?php
+?>comp HTMS;pot HTMS<?php
 echo "\n";
 
 //correction bug age joueurs par jojoje86 le 20/07/09

--- a/dtn/interface/outils/ExportCsv.php
+++ b/dtn/interface/outils/ExportCsv.php
@@ -100,7 +100,7 @@ switch ($sens) {
 		$tri = "Tri decroissant";
 		break;
 }
-?>NomJoueur;idHattrick;Date Maj DTN;Date Maj Proprio;last maj(jours);age;jours;xp;leader;spe;endu;construction;+;ailier;+;buteur;+;gardien;+;passe;+;defenseur;+;coup francs;entraineur;entrainement;DTN;note<?php
+?>NomJoueur;idHattrick;Date Maj DTN;Date Maj Proprio;last maj(jours);age;jours;tsi;salaire;xp;leader;spe;endu;construction;+;ailier;+;buteur;+;gardien;+;passe;+;defenseur;+;coup francs;entraineur;entrainement;DTN;note<?php
 switch ($sesUser["idPosition_fk"]) {
 	case "1" : //gK
 ?> gardien;<?php
@@ -139,6 +139,15 @@ if ($typeExport=="unjoueur") {$sql .="from $tbl_joueurs where idHattrickJoueur =
 foreach ($conn->query($sql) as $l) {
 	$infJ = getJoueur($l["idJoueur"]);
 	$date = explode("-",$infJ["dateDerniereModifJoueur"]);
+    
+    // Extraction tsi
+            $sql4= "SELECT tsi FROM $tbl_joueurs_histo
+                   WHERE id_joueur_fk=".$l["idHattrickJoueur"]." 
+                   ORDER BY date_histo DESC LIMIT 1";
+            $req4 = $conn->query($sql4);
+            $ligne4 = $req4->fetch(PDO::FETCH_ASSOC);
+            if (is_array($ligne4))
+            extract($ligne4);
 
 	$mkJoueur =  mktime(0,0,0,$date[1],$date[2],$date[0]); 
 	$datesaisie = explode("-",$infJ["dateSaisieJoueur"]);
@@ -157,13 +166,15 @@ foreach ($conn->query($sql) as $l) {
 	echo round(($mkday - $datemaj)/(60*60*24) ).";";
 	echo $l["AgeAn"].";";
 	echo $l["AgeJour"].";";
+	echo $tsi.";";
+	echo $l["salary"].";";
 	echo $l["idExperience_fk"].";";
 	echo $l["idLeader_fk"].";";
 	echo $specabbrevs[$l["optionJoueur"]].";";
 	echo $l["idEndurance"].";";
 
 
-	echo $l["idConstruction"].";".$infJ["nbSemaineConstruction"].";"; 
+	echo  $l["idConstruction"].";".$infJ["nbSemaineConstruction"].";"; 
 	echo  $l["idAilier"].";".$infJ["nbSemaineAilier"].";";
 	echo  $l["idButeur"].";".$infJ["nbSemaineButeur"].";";
 	echo  $l["idGardien"].";".$infJ["nbSemaineGardien"].";";

--- a/dtn/interface/outils/ExportCsv.php
+++ b/dtn/interface/outils/ExportCsv.php
@@ -100,7 +100,7 @@ switch ($sens) {
 		$tri = "Tri decroissant";
 		break;
 }
-?>NomJoueur;idHattrick;Date Maj DTN;Date Maj Proprio;last maj(jours);age;jours;xp;leader;spe;endu;construction;+;ailier;+;buteur;+;gardien;+;passe;+;defenseur;+;coup francs;entraineur;entrainement;DTN;note<?php
+?>NomJoueur;idHattrick;Date Maj DTN;Date Maj Proprio;last maj(jours);age;jours;xp;leader;spe;endu;construction;+;ailier;+;buteur;+;gardien;+;passe;+;defenseur;+;coup francs;+;entraineur;entrainement;DTN;note<?php
 switch ($sesUser["idPosition_fk"]) {
 	case "1" : //gK
 ?> gardien;<?php
@@ -169,7 +169,7 @@ foreach ($conn->query($sql) as $l) {
 	echo  $l["idGardien"].";".$infJ["nbSemaineGardien"].";";
 	echo  $l["idPasse"].";".$infJ["nbSemainePasses"].";"; 
 	echo  $l["idDefense"].";".$infJ["nbSemaineDefense"].";";
-	echo  $l["idPA"].";";
+	echo  $l["idPA"].";".$infJ["nbSemaineCoupFranc"].";";
 
 	echo $infJ["niv_Entraineur"].";";
 	$nom_entrainement=utf8_decode(getEntrainementName($infJ["entrainement_id"],$listEntrainement));

--- a/dtn/interface/outils/ExportCsv.php
+++ b/dtn/interface/outils/ExportCsv.php
@@ -100,7 +100,7 @@ switch ($sens) {
 		$tri = "Tri decroissant";
 		break;
 }
-?>NomJoueur;idHattrick;Date Maj DTN;Date Maj Proprio;last maj(jours);age;jours;xp;leader;spe;endu;construction;+;ailier;+;buteur;+;gardien;+;passe;+;defenseur;+;coup francs;+;entraineur;entrainement;DTN;note<?php
+?>NomJoueur;idHattrick;Date Maj DTN;Date Maj Proprio;last maj(jours);age;jours;tsi;salaire;xp;leader;spe;endu;tx endu;construction;+;ailier;+;buteur;+;gardien;+;passe;+;defenseur;+;coup francs;+;entraineur;entrainement;DTN;note<?php
 
 switch ($sesUser["idPosition_fk"]) {
 	case "1" : //gK
@@ -150,6 +150,16 @@ foreach ($conn->query($sql) as $l) {
             if (is_array($ligne4))
             extract($ligne4);
 
+    // Extraction taux d'endurance du joueur
+            $endurance="-";
+            $sql2 = "SELECT endurance FROM $tbl_clubs_histo 
+                    WHERE idClubHT = ".$l["teamid"]."
+                    ORDER BY date_histo DESC LIMIT 1";
+            $req2 = $conn->query($sql2);
+            $ligne2 = $req2->fetch(PDO::FETCH_ASSOC);
+            if (is_array($ligne2))
+            extract($ligne2);
+            
 	$mkJoueur =  mktime(0,0,0,$date[1],$date[2],$date[0]); 
 	$datesaisie = explode("-",$infJ["dateSaisieJoueur"]);
 	$mkSaisieJoueur= mktime(0,0,0,$datesaisie[1],$datesaisie[2],$datesaisie[0]);
@@ -173,7 +183,7 @@ foreach ($conn->query($sql) as $l) {
 	echo $l["idLeader_fk"].";";
 	echo $specabbrevs[$l["optionJoueur"]].";";
 	echo $l["idEndurance"].";";
-
+    echo $endurance."%;";
 
 	echo  $l["idConstruction"].";".$infJ["nbSemaineConstruction"].";"; 
 	echo  $l["idAilier"].";".$infJ["nbSemaineAilier"].";";

--- a/dtn/interface/planification/training.php
+++ b/dtn/interface/planification/training.php
@@ -19,6 +19,7 @@ foreach($conn->query($sql) as $result){
 	$semaine["defense"] = $result["nbSemaineDefense"];
 	$semaine["buteur"] = $result["nbSemaineButeur"];
 	$semaine["ailier"] = $result["nbSemaineAilier"] ;
+	$semaine["coupfranc"] = $result["nbSemaineCoupFranc"] ;
 
 /*
 switch($result["entrainement_id"]){

--- a/dtn/interface/settings.php
+++ b/dtn/interface/settings.php
@@ -36,10 +36,10 @@ if (isset($_GET['affCoeff']))
 	$affCoeff = $_GET['affCoeff'];
 if (isset($_GET['affinfoPerso']))
 	$affinfoPerso = $_GET['affinfoPerso'];
-if (isset($_POST['mod']))
-	$mod=$_POST['mod'];
-if (isset($_POST['modperso']))
-	$modperso=$_POST['modperso'];
+if (isset($_GET['mod']))
+	$mod=$_GET['mod'];
+if (isset($_GET['modperso']))
+	$modperso=$_GET['modperso'];
 
 $lstPos = listPosition();
 if(!isset($id_postes)) $id_postes = 1;
@@ -83,7 +83,11 @@ if ($affinfoPerso == 1) {
 		  </tr>
 		  <tr>
 			<td>Mot de passe :</td>
-			<td> <input name="mdp" type="text" id="mdp" ></td>
+			<td> <input name="mdp" type="password" id="mdp" ></td>
+		  </tr>
+		  <tr>
+			<td>Confirmer le Mot de passe :</td>
+			<td> <input name="mdp2" type="password" id="mdp2" ></td>
 		  </tr>
 		  <tr>
 			<td>Email :</td>
@@ -116,6 +120,7 @@ if ($affinfoPerso == 1) {
         <font color="#FF0000">
 <?php if($mod=="ok") echo "Modifications correctements effectu&eacute;es";?>
 <?php if($modperso=="ok") echo "Modifications correctement effectu&eacute;es, vous devez vous d&eacute;connecter pour que les changements prennent effet";?>
+<?php if($modperso=="ohno") echo "Echec de la mise &agrave; jour des donn&eacute;es";?>
 		</font>
 		</center>
 		</td>

--- a/dtn/interface/settings.php
+++ b/dtn/interface/settings.php
@@ -83,7 +83,7 @@ if ($affinfoPerso == 1) {
 		  </tr>
 		  <tr>
 			<td>Mot de passe :</td>
-			<td> <input name="mdp" type="text" id="mdp" value="<?=$_SESSION['sesUser']["passAdmin"]?>"></td>
+			<td> <input name="mdp" type="text" id="mdp" ></td>
 		  </tr>
 		  <tr>
 			<td>Email :</td>


### PR DESCRIPTION
Affin de résoudre le problème d'affichage : 
- le menuJoueur.php, basé sur la variable $joueurDTN est inchangé, et s'applique aux 2 url associés à fiche.php
- création d'un fichier menuJoueur_autres_onglets.php, basé lui sur la variable $infJ, utilisé pour les ficheForum, hisoModifs, ficheSlack, ficheResume, ficheHattrick (ces fichiers utilisant la variable $inf J).

Avec ces 2 fichiers, plus de problèmes d'affichage des menus des onglets des joueurs d'un autre secteur.
Testé en local.